### PR TITLE
feat: show commands with mode toggle

### DIFF
--- a/src/torrra/app.py
+++ b/src/torrra/app.py
@@ -15,7 +15,11 @@ from torrra.utils.provider import load_provider
 class TorrraApp(App):
     TITLE = "torrra"
     CSS_PATH = "app.css"
-    BINDINGS = [("q", "quit", "Quit")]
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+        ("d", "toggle_dark_mode", "Toggle dark mode"),
+        ("escape", "clear_focus", "Clear focus"),
+    ]
     ENABLE_COMMAND_PALETTE = False
 
     def __init__(self, provider: Optional[Provider]) -> None:
@@ -29,6 +33,16 @@ class TorrraApp(App):
         if query := await self.push_screen_wait(WelcomeScreen(provider=self.provider)):
             search_screen = SearchScreen(provider=self.provider, initial_query=query)
             await self.push_screen(search_screen)
+
+    def action_toggle_dark_mode(self) -> None:
+        self.theme = (
+            "catppuccin-mocha"
+            if self.theme == "catppuccin-latte"
+            else "catppuccin-latte"
+        )
+
+    def action_clear_focus(self) -> None:
+        self.set_focus(None)
 
 
 def main():

--- a/src/torrra/app.py
+++ b/src/torrra/app.py
@@ -16,6 +16,7 @@ class TorrraApp(App):
     TITLE = "torrra"
     CSS_PATH = "app.css"
     BINDINGS = [("q", "quit", "Quit")]
+    ENABLE_COMMAND_PALETTE = False
 
     def __init__(self, provider: Optional[Provider]) -> None:
         super().__init__()

--- a/src/torrra/screens/welcome.css
+++ b/src/torrra/screens/welcome.css
@@ -18,3 +18,31 @@ WelcomeScreen #subtitle {
 WelcomeScreen #version {
     color: $foreground-muted;
 }
+
+WelcomeScreen #commands_container {
+    margin-top: 1;
+    align-horizontal: center;
+}
+
+WelcomeScreen #commands_container Grid {
+    width: 75%;
+    height: 3;
+    grid-size: 2;
+    grid-columns: 1fr auto;
+}
+
+WelcomeScreen #commands_container Grid Static {
+    text-align: left;
+    color: $foreground-muted;
+}
+
+WelcomeScreen #commands_container Grid Static#title {
+    text-align: center;
+    column-span: 2;
+    color: $text-secondary;
+}
+
+WelcomeScreen #commands_container Grid Static.key {
+    text-align: right;
+    color: $text-secondary;
+}

--- a/src/torrra/screens/welcome.py
+++ b/src/torrra/screens/welcome.py
@@ -41,10 +41,12 @@ class WelcomeScreen(Screen[str]):
             with Container(id="commands_container"):
                 with Grid(id="commands"):
                     yield Static("[commands]", id="title", markup=False)
-                    yield Static("[q]uit", markup=False)
-                    yield Static("q", classes="key")
+                    yield Static("[esc]ape focus", markup=False)
+                    yield Static("esc", classes="key")
                     yield Static("toggle [d]ark mode", markup=False)
                     yield Static("d", classes="key")
+                    yield Static("[q]uit", markup=False)
+                    yield Static("q", classes="key")
 
     @on(Input.Submitted, "#search")
     async def handle_search(self, event: Input.Submitted) -> None:

--- a/src/torrra/screens/welcome.py
+++ b/src/torrra/screens/welcome.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from textual import on
 from textual.app import ComposeResult
-from textual.containers import Container
+from textual.containers import Container, Grid
 from textual.screen import Screen
 from textual.widgets import Input, Static
 
@@ -38,6 +38,13 @@ class WelcomeScreen(Screen[str]):
             yield Input(placeholder="Search...", id="search")
             provider_name = f" - {self.provider.name}" if self.provider else ""
             yield Static(f"v{__version__}{provider_name}", id="version")
+            with Container(id="commands_container"):
+                with Grid(id="commands"):
+                    yield Static("[commands]", id="title", markup=False)
+                    yield Static("[q]uit", markup=False)
+                    yield Static("q", classes="key")
+                    yield Static("toggle [d]ark mode", markup=False)
+                    yield Static("d", classes="key")
 
     @on(Input.Submitted, "#search")
     async def handle_search(self, event: Input.Submitted) -> None:


### PR DESCRIPTION
List available commands on the `WelcomeScreen`:

<img width="580" height="360" alt="image" src="https://github.com/user-attachments/assets/a699b9f1-28fe-4590-a863-83959e6f17e8" />

 - Added `d` key binding to toggle dark mode
 - Added `esc` key binding to escape currently focused widget