### PR TITLE
fix: error message in case Jackett is not installed locally

### DIFF
--- a/src/torrra/utils/provider.py
+++ b/src/torrra/utils/provider.py
@@ -12,8 +12,31 @@ def load_provider(provider: Literal["jackett"]) -> Provider:
         return load_jackett_config()
 
 
+def find_jackett_config() -> Path:
+    # Default per-user config location
+    default_path = Path(user_config_dir("Jackett")) / "ServerConfig.json"
+    if default_path.exists():
+        return default_path
+
+    # Common system-wide config location (e.g., Windows service install)
+    alt_path = Path("C:/ProgramData/Jackett/ServerConfig.json")
+    if alt_path.exists():
+        return alt_path
+
+    # Could add more fallback paths here if needed
+
+    # If nothing found, raise helpful error
+    raise RuntimeError(
+        "[ERROR] Jackett config file not found in known locations.\n"
+        "Checked:\n"
+        f"  {default_path}\n"
+        f"  {alt_path}\n"
+        "Please ensure Jackett is installed and has run at least once."
+    )
+
+
 def load_jackett_config() -> Provider:
-    config_path = Path(user_config_dir("Jackett")) / "ServerConfig.json"
+    config_path = find_jackett_config()
     config = _load_json_config(config_path)
 
     port = config.get("Port", 9117)


### PR DESCRIPTION
So when I tried to install Jackett and test it on my local computer, the Jackett app and its Serverconfig file was actually located in "C:\Programs\Jackett" instead of "C:\Users\<User>\AppData\Local\Jackett" like in the platformdirs library. It could have potentially caused problem when you try it on Windows.

This is like my first Good first issue so just let me know if something is wrong, I'll try my best to fix it. 
Cheers.