### PR TITLE
feat: expose jackett provider flags

### DIFF
--- a/src/torrra/app.py
+++ b/src/torrra/app.py
@@ -11,7 +11,7 @@ from torrra.screens.search import SearchScreen
 from torrra.screens.welcome import WelcomeScreen
 from torrra.utils.cli import parse_cli_args
 from torrra.utils.fs import get_resource_path
-from torrra.utils.provider import load_provider
+from torrra.utils.provider import load_provider, load_provider_from_args
 
 
 class TorrraApp(App):
@@ -54,6 +54,10 @@ def main():
     try:
         if args.jackett:
             provider = load_provider("jackett")
+        elif args.jackett_url and args.jackett_api_key:
+            provider = load_provider_from_args(
+                "jackett", args.jackett_url, args.jackett_api_key
+            )
         elif args.command == "config":
             handle_config_command(args)
             sys.exit()

--- a/src/torrra/providers/jackett.py
+++ b/src/torrra/providers/jackett.py
@@ -27,12 +27,21 @@ class JackettClient:
                 resp = await client.get(url, params=params)
                 resp.raise_for_status()
                 return True
-            except httpx.RequestError as e:
-                print(f"[error] jackett: connection error: {e}")
+
+            except httpx.RequestError:
+                print(f"[error] could not connect to jackett at {self.url}.")
+                print("please make sure jackett is running and the url is correct.")
+
             except httpx.HTTPStatusError as e:
                 status_code = e.response.status_code
+
                 if status_code == 401:
-                    print("[error] jackett: invalid api key")
+                    print("[error] invalid jackett api key.")
+                    print("double-check the api key you provided.")
                 elif status_code == 500 and "nonexistent_indexer" in e.response.text:
                     return True
+                else:
+                    print(f"[error] jackett returned http {status_code}.")
+                    print("unexpected response from jackett. please verify your setup.")
+
             return False

--- a/src/torrra/providers/jackett.py
+++ b/src/torrra/providers/jackett.py
@@ -17,3 +17,22 @@ class JackettClient:
             resp = await client.get(endpoint, params=params)
             resp.raise_for_status()
             return resp.json().get("Results", [])
+
+    async def validate(self) -> bool:
+        url = f"{self.url}/api/v2.0/indexers/nonexistent_indexer/results"
+        params = {"apikey": self.api_key}
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            try:
+                resp = await client.get(url, params=params)
+                resp.raise_for_status()
+                return True
+            except httpx.RequestError as e:
+                print(f"[error] jackett: connection error: {e}")
+            except httpx.HTTPStatusError as e:
+                status_code = e.response.status_code
+                if status_code == 401:
+                    print("[error] jackett: invalid api key")
+                elif status_code == 500 and "nonexistent_indexer" in e.response.text:
+                    return True
+            return False

--- a/src/torrra/utils/cli.py
+++ b/src/torrra/utils/cli.py
@@ -17,6 +17,10 @@ def parse_cli_args():
     parser.add_argument(
         "-j", "--jackett", action="store_true", help="use Jackett provider"
     )
+    parser.add_argument("--jackett-url", metavar="URL", help="override the Jackett URL")
+    parser.add_argument(
+        "--jackett-api-key", metavar="API_KEY", help="override the Jackett API key"
+    )
 
     # "config" sub-command
     config_parser = subparsers.add_parser("config", help="configure torrra")

--- a/src/torrra/utils/cli.py
+++ b/src/torrra/utils/cli.py
@@ -17,9 +17,9 @@ def parse_cli_args():
     parser.add_argument(
         "-j", "--jackett", action="store_true", help="use Jackett provider"
     )
-    parser.add_argument("--jackett-url", metavar="URL", help="override the Jackett URL")
+    parser.add_argument("--jackett-url", metavar="URL", help="provide your Jackett URL")
     parser.add_argument(
-        "--jackett-api-key", metavar="API_KEY", help="override the Jackett API key"
+        "--jackett-api-key", metavar="API_KEY", help="provide your Jackett API key"
     )
 
     # "config" sub-command

--- a/src/torrra/utils/provider.py
+++ b/src/torrra/utils/provider.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from pathlib import Path
 from typing import Dict, Literal
@@ -5,11 +6,23 @@ from typing import Dict, Literal
 from platformdirs import site_config_dir, user_config_dir
 
 from torrra._types import Provider
+from torrra.providers.jackett import JackettClient
 
 
 def load_provider(provider: Literal["jackett"]) -> Provider:
     if provider == "jackett":
         return load_jackett_config()
+
+
+def load_provider_from_args(
+    name: Literal["jackett"], url: str, api_key: str
+) -> Provider:
+    if name == "jackett":
+        jc = JackettClient(url=url, api_key=api_key)
+        if asyncio.run(jc.validate()):
+            return Provider(name="Jackett", url=url, api_key=api_key)
+        else:
+            raise SystemExit(1)
 
 
 def load_jackett_config() -> Provider:

--- a/src/torrra/utils/provider.py
+++ b/src/torrra/utils/provider.py
@@ -38,7 +38,11 @@ def load_jackett_config() -> Provider:
     except KeyError:
         raise RuntimeError(f"[error] 'APIKey' not found in config: {config_path}")
 
-    return Provider(name="Jackett", url=url, api_key=api_key)
+    jc = JackettClient(url=url, api_key=api_key)
+    if asyncio.run(jc.validate()):
+        return Provider(name="Jackett", url=url, api_key=api_key)
+    else:
+        raise SystemExit(1)
 
 
 def _find_jackett_config_path() -> Path:


### PR DESCRIPTION
Jackett cmd flags:
```bash
  --jackett-url URL     provide your Jackett URL
  --jackett-api-key API_KEY
                        provide your Jackett API key
```

Added error handling and validation of jackett client.
extra `validate()` method for client.

Resolves #38 