### PR TITLE
refactor: validate indexers before run

### DIFF
--- a/src/torrra/__main__.py
+++ b/src/torrra/__main__.py
@@ -1,13 +1,12 @@
 import click
 
 from torrra._version import __version__
-from torrra.core.exceptions import ConfigError
 
 
 @click.group(invoke_without_command=True)
 @click.version_option(version=__version__, prog_name="torrra")
 @click.pass_context
-def cli(ctx: click.Context):
+def cli(ctx: click.Context) -> None:
     if not ctx.invoked_subcommand:
         # run app
         pass
@@ -19,19 +18,49 @@ def cli(ctx: click.Context):
 @cli.command(help="Use Jackett as the indexer.")
 @click.option("--url", required=True, help="Jackett server URL.")
 @click.option("--api-key", required=True, help="Jackett API key.")
-def jackett(url: str, api_key: str):
+def jackett(url: str, api_key: str) -> None:
+    click.secho(f"connecting to jackett server at: {url}", fg="cyan")
+
+    import asyncio
+
+    from torrra.core.exceptions import JackettConnectionError
+    from torrra.indexers.jackett import JackettIndexer
     from torrra.utils.indexer import run_with_indexer
 
-    run_with_indexer("jackett", url, api_key)
+    async def validate_indexer() -> bool:
+        try:
+            return await JackettIndexer(url, api_key).validate()
+        except JackettConnectionError as e:
+            click.secho(e, fg="red", err=True)
+            return False
+
+    valid = asyncio.run(validate_indexer())
+    if valid:
+        run_with_indexer("jackett", url, api_key)
 
 
 @cli.command(help="Use Prowlarr as the indexer.")
 @click.option("--url", required=True, help="Prowlarr server URL.")
 @click.option("--api-key", required=True, help="Prowlarr API key.")
 def prowlarr(url: str, api_key: str):
+    click.secho(f"connecting to prowlarr server at: {url}", fg="cyan")
+
+    import asyncio
+
+    from torrra.core.exceptions import ProwlarrConnectionError
+    from torrra.indexers.prowlarr import ProwlarrIndexer
     from torrra.utils.indexer import run_with_indexer
 
-    run_with_indexer("prowlarr", url, api_key)
+    async def validate_indexer() -> bool:
+        try:
+            return await ProwlarrIndexer(url, api_key).validate()
+        except ProwlarrConnectionError as e:
+            click.secho(e, fg="red", err=True)
+            return False
+
+    valid = asyncio.run(validate_indexer())
+    if valid:
+        run_with_indexer("prowlarr", url, api_key)
 
 
 # ========== CONFIG ==========
@@ -46,6 +75,7 @@ def config():
 @click.argument("key")
 def config_get(key: str):
     from torrra.core.config import Config
+    from torrra.core.exceptions import ConfigError
 
     config = Config()
     try:
@@ -59,6 +89,7 @@ def config_get(key: str):
 @click.argument("value")
 def config_set(key: str, value: str):
     from torrra.core.config import Config
+    from torrra.core.exceptions import ConfigError
 
     config = Config()
     try:
@@ -70,6 +101,7 @@ def config_set(key: str, value: str):
 @config.command(name="list", help="List all configurations.")
 def config_list():
     from torrra.core.config import Config
+    from torrra.core.exceptions import ConfigError
 
     config = Config()
     try:

--- a/src/torrra/_types.py
+++ b/src/torrra/_types.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, TypedDict
+
+# ========== TORRENTS ==========
 
 
 @dataclass
@@ -12,11 +14,23 @@ class Torrent:
     magnet_uri: str | None
 
 
-Indexers = Literal["jackett", "prowlarr"]
+class TorrentDict(TypedDict):
+    title: str
+    size: float
+    seeders: int
+    leechers: int
+    source: str
+    magnet_uri: str
+
+
+# ========== INDEXERS ==========
+
+
+IndexerName = Literal["jackett", "prowlarr"]
 
 
 @dataclass
-class Provider:
-    name: Indexers
+class Indexer:
+    name: IndexerName
     url: str
     api_key: str

--- a/src/torrra/_types.py
+++ b/src/torrra/_types.py
@@ -1,7 +1,15 @@
-from dataclasses import dataclass
-from typing import Literal, TypedDict
+from dataclasses import asdict, dataclass
+from typing import Any, Literal, TypedDict, cast
 
-# ========== TORRENTS ==========
+
+# TORRENT TYPES
+class TorrentDict(TypedDict):
+    title: str
+    size: float
+    seeders: int
+    leechers: int
+    source: str
+    magnet_uri: str | None
 
 
 @dataclass
@@ -13,19 +21,15 @@ class Torrent:
     source: str
     magnet_uri: str | None
 
+    @classmethod
+    def from_dict(cls, d: TorrentDict) -> "Torrent":
+        return cls(**d)
 
-class TorrentDict(TypedDict):
-    title: str
-    size: float
-    seeders: int
-    leechers: int
-    source: str
-    magnet_uri: str
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
 
-# ========== INDEXERS ==========
-
-
+# INDEXER TYPES
 IndexerName = Literal["jackett", "prowlarr"]
 
 

--- a/src/torrra/app.py
+++ b/src/torrra/app.py
@@ -5,7 +5,7 @@ from textual.app import App
 from textual.binding import BindingType
 from textual.types import CSSPathType
 
-from torrra._types import Provider
+from torrra._types import Indexer
 from torrra.screens.welcome import WelcomeScreen
 from torrra.utils.fs import get_resource_path
 
@@ -20,9 +20,9 @@ class TorrraApp(App[None]):
     ]
     ENABLE_COMMAND_PALETTE: ClassVar[bool] = False
 
-    def __init__(self, provider: Provider | None) -> None:
+    def __init__(self, provider: Indexer | None) -> None:
         super().__init__()
-        self.provider: Provider | None = provider
+        self.provider: Indexer | None = provider
 
     @work
     async def on_mount(self) -> None:
@@ -33,7 +33,7 @@ class TorrraApp(App[None]):
         if query := await self.push_screen_wait(WelcomeScreen(provider=self.provider)):
             from torrra.screens.search import SearchScreen
 
-            search_screen = SearchScreen(provider=self.provider, initial_query=query)
+            search_screen = SearchScreen(indexer=self.provider, initial_query=query)
             await self.push_screen(search_screen)
 
     def action_toggle_dark_mode(self) -> None:

--- a/src/torrra/core/cache.py
+++ b/src/torrra/core/cache.py
@@ -1,15 +1,37 @@
 import atexit
 import hashlib
+from typing import Any, cast
 
 # no official stubs for diskcache
 from diskcache import Cache  # pyright: ignore[reportMissingTypeStubs]
 from platformdirs import user_cache_dir
 
-CACHE_DIR = user_cache_dir("torrra")
-CACHE_TTL = 300  # 5 mins
+from torrra.core.constants import CACHE_TTL
 
-cache = Cache(CACHE_DIR)
+cache = Cache(user_cache_dir("torrra"))
 atexit.register(cache.close)
+
+# ========== CACHE FUNCTIONS ========== #
+
+
+def has_cache(key: str) -> bool:
+    return key in cache
+
+
+def get_cache(key: str) -> Any:
+    return cast(Any, cache[key])
+
+
+def set_cache(key: str, value: Any, expire: int = CACHE_TTL) -> None:
+    cache.set(key, value, expire=expire)  # pyright: ignore[reportUnknownMemberType]
+
+
+def delete_cache(key: str) -> None:
+    if key in cache:
+        del cache[key]
+
+
+# ========== CACHE UTILS ========== #
 
 
 def make_cache_key(prefix: str, query: str) -> str:

--- a/src/torrra/core/constants.py
+++ b/src/torrra/core/constants.py
@@ -1,0 +1,1 @@
+CACHE_TTL = 300  # 5 mins

--- a/src/torrra/core/exceptions.py
+++ b/src/torrra/core/exceptions.py
@@ -2,3 +2,15 @@ class ConfigError(Exception):
     """Custom error for config key issues."""
 
     pass
+
+
+class JackettConnectionError(Exception):
+    """Raised when Jackett is unreachable or misconfigured."""
+
+    pass
+
+
+class ProwlarrConnectionError(Exception):
+    """Raised when Prowlarr is unreachable or misconfigured."""
+
+    pass

--- a/src/torrra/indexers/prowlarr.py
+++ b/src/torrra/indexers/prowlarr.py
@@ -4,29 +4,28 @@ import httpx
 
 from torrra._types import Torrent
 from torrra.core.cache import CACHE_TTL, cache, make_cache_key
+from torrra.core.exceptions import ProwlarrConnectionError
 
 
-class JackettClient:
+class ProwlarrIndexer:
     def __init__(self, url: str, api_key: str, timeout: int = 10):
         self.url: str = url.rstrip("/")
         self.api_key: str = api_key
         self.timeout: int = timeout
 
     async def search(self, query: str, use_cache: bool = True) -> list[Torrent]:
-        # jackett has build-in cache mechanism
-        key = make_cache_key("jackett", query)
+        key = make_cache_key("prowlarr", query)
 
         if use_cache and key in cache:
             return cast(list[Torrent], cache[key])
 
-        endpoint = f"{self.url}/api/v2.0/indexers/all/results"
+        endpoint = f"{self.url}/api/v1/search"
         params = {"apikey": self.api_key, "query": query}
 
         async with httpx.AsyncClient(timeout=self.timeout) as client:
             resp = await client.get(endpoint, params=params)
             resp.raise_for_status()
-            raw_results = resp.json().get("Results", [])
-            results = [self._normalize_result(r) for r in raw_results]
+            results = [self._normalize_result(r) for r in resp.json()]
 
         if use_cache:
             # cache.set might be missing type hints on set()
@@ -37,7 +36,7 @@ class JackettClient:
         return results
 
     async def validate(self) -> bool:
-        url = f"{self.url}/api/v2.0/indexers/nonexistent_indexer/results"
+        url = f"{self.url}/api/v1/health"
         params = {"apikey": self.api_key}
 
         async with httpx.AsyncClient(timeout=self.timeout) as client:
@@ -47,29 +46,31 @@ class JackettClient:
                 return True
 
             except httpx.RequestError:
-                print(f"[error] could not connect to jackett at {self.url}.")
-                print("please make sure jackett is running and the url is correct.")
+                raise ProwlarrConnectionError(
+                    f"could not connect to prowlarr at {self.url}\n"
+                    + "please make sure prowlarr is running and the url is correct"
+                )
 
             except httpx.HTTPStatusError as e:
                 status_code = e.response.status_code
 
                 if status_code == 401:
-                    print("[error] invalid jackett api key.")
-                    print("double-check the api key you provided.")
-                elif status_code == 500 and "nonexistent_indexer" in e.response.text:
-                    return True
+                    raise ProwlarrConnectionError(
+                        "invalid prowlarr api key\n"
+                        + "double-check the api key you provided"
+                    )
                 else:
-                    print(f"[error] jackett returned http {status_code}.")
-                    print("unexpected response from jackett. please verify your setup.")
-
-            return False
+                    raise ProwlarrConnectionError(
+                        f"prowlarr returned http {status_code}\n"
+                        + "unexpected response from prowlarr. please verify your setup"
+                    )
 
     def _normalize_result(self, r: dict[str, Any]) -> Torrent:
         return Torrent(
-            title=r.get("Title", ""),
-            size=r.get("Size", 0),
-            seeders=r.get("Seeders", 0),
-            leechers=r.get("Peers", 0),
-            source=r.get("Tracker", "unknown"),
-            magnet_uri=r.get("MagnetUri", None),
+            title=r.get("title", ""),
+            size=r.get("size", 0),
+            seeders=r.get("seeders", 0),
+            leechers=r.get("leechers", 0),
+            source=r.get("indexer", "unknown"),
+            magnet_uri=r.get("magnetUrl", None),
         )

--- a/src/torrra/screens/search.py
+++ b/src/torrra/screens/search.py
@@ -12,10 +12,10 @@ from textual.types import CSSPathType
 from textual.widgets import DataTable, Input, LoadingIndicator, ProgressBar, Static
 from textual.widgets.data_table import ColumnKey
 
-from torrra._types import Provider, Torrent
+from torrra._types import Indexer, Torrent
 from torrra.core.config import Config
-from torrra.providers.jackett import JackettClient
-from torrra.providers.prowlarr import ProwlarrClient
+from torrra.indexers.jackett import JackettIndexer
+from torrra.indexers.prowlarr import ProwlarrIndexer
 from torrra.utils.fs import get_resource_path
 from torrra.utils.helpers import human_readable_size
 
@@ -43,9 +43,9 @@ class SearchScreen(Screen[None]):
             self.query: str = query
             super().__init__()
 
-    def __init__(self, provider: Provider | None, initial_query: str):
+    def __init__(self, indexer: Indexer | None, initial_query: str):
         super().__init__()
-        self.provider: Provider | None = provider
+        self.indexer: Indexer | None = indexer
         self.initial_query: str = initial_query
         # libtorrent
         self.lt_session: lt.session | None = None
@@ -171,7 +171,7 @@ class SearchScreen(Screen[None]):
 
     @work(exclusive=True, thread=True)
     async def _perform_search(self, query: str) -> None:
-        client = self._get_client()
+        client = self._get_indexer()
         results = []
         if client:
             try:
@@ -281,14 +281,14 @@ class SearchScreen(Screen[None]):
             progress=progress
         )
 
-    def _get_client(self) -> JackettClient | ProwlarrClient | None:
-        if not self.provider:
+    def _get_indexer(self) -> JackettIndexer | ProwlarrIndexer | None:
+        if not self.indexer:
             return
 
-        if self.provider.name == "jackett":
-            return JackettClient(url=self.provider.url, api_key=self.provider.api_key)
-        elif self.provider.name == "prowlarr":
-            return ProwlarrClient(url=self.provider.url, api_key=self.provider.api_key)
+        if self.indexer.name == "jackett":
+            return JackettIndexer(url=self.indexer.url, api_key=self.indexer.api_key)
+        elif self.indexer.name == "prowlarr":
+            return ProwlarrIndexer(url=self.indexer.url, api_key=self.indexer.api_key)
 
     async def _resolve_magnet_uri_if_redirect(self, url: str) -> str:
         if url.startswith("magnet:"):

--- a/src/torrra/screens/welcome.py
+++ b/src/torrra/screens/welcome.py
@@ -7,7 +7,7 @@ from textual.screen import Screen
 from textual.types import CSSPathType
 from textual.widgets import Input, Static
 
-from torrra._types import Provider
+from torrra._types import Indexer
 from torrra._version import __version__
 from torrra.utils.fs import get_resource_path
 
@@ -21,9 +21,9 @@ BANNER = """
 class WelcomeScreen(Screen[str]):
     CSS_PATH: ClassVar[CSSPathType | None] = get_resource_path("screens/welcome.css")
 
-    def __init__(self, provider: Provider | None) -> None:
+    def __init__(self, provider: Indexer | None) -> None:
         super().__init__()
-        self.provider: Provider | None = provider
+        self.provider: Indexer | None = provider
 
     @override
     def compose(self) -> ComposeResult:

--- a/src/torrra/utils/indexer.py
+++ b/src/torrra/utils/indexer.py
@@ -2,15 +2,15 @@ import sys
 
 import click
 
-from torrra._types import Indexers, Provider
+from torrra._types import Indexer, IndexerName
 from torrra.core.exceptions import ConfigError
 
 
-def run_with_indexer(indexer: Indexers, url: str, api_key: str):
+def run_with_indexer(indexer: IndexerName, url: str, api_key: str):
     from torrra.app import TorrraApp
 
     try:
-        provider = Provider(indexer, url, api_key)
+        provider = Indexer(indexer, url, api_key)
         app = TorrraApp(provider=provider)
         app.run()
     except (FileNotFoundError, RuntimeError, ConfigError) as e:


### PR DESCRIPTION
```console
connecting to jackett server at: http://localhost:9117
// if invalid
invalid jackett api key
double-check the api key you provided
```

Potential fixes for:
 - #60 
 - #71 