### PR TITLE
feat(cli): run default indexer when no subcommand is passed

### DIFF
--- a/src/torrra/__main__.py
+++ b/src/torrra/__main__.py
@@ -5,12 +5,13 @@ from torrra._version import __version__
 
 @click.group(invoke_without_command=True)
 @click.version_option(version=__version__, prog_name="torrra")
+@click.option("--no-cache", is_flag=True, help="Disable caching mechanism.")
 @click.pass_context
-def cli(ctx: click.Context) -> None:
+def cli(ctx: click.Context, no_cache: bool) -> None:
     if not ctx.invoked_subcommand:
         from torrra.utils.indexer import auto_detect_indexer_and_run
 
-        auto_detect_indexer_and_run()
+        auto_detect_indexer_and_run(no_cache)
 
 
 # ========== INDEXERS ==========

--- a/src/torrra/__main__.py
+++ b/src/torrra/__main__.py
@@ -38,7 +38,7 @@ def jackett(url: str | None, api_key: str | None, no_cache: bool) -> None:
 @click.option("--url", required=False, help="Prowlarr server URL.")
 @click.option("--api-key", required=False, help="Prowlarr API key.")
 @click.option("--no-cache", is_flag=True, help="Disable caching mechanism.")
-def prowlarr(url: str, api_key: str, no_cache: bool):
+def prowlarr(url: str | None, api_key: str | None, no_cache: bool):
     from torrra.utils.indexer import handle_indexer_command
 
     handle_indexer_command(
@@ -62,11 +62,11 @@ def config():
 @config.command(name="get", help="Get a config value.")
 @click.argument("key")
 def config_get(key: str):
-    from torrra.core.context import config
+    from torrra.core.context import config as cfg
     from torrra.core.exceptions import ConfigError
 
     try:
-        click.echo(config.get(key))
+        click.echo(cfg.get(key))
     except ConfigError as e:
         click.secho(e, fg="red", err=True)
 
@@ -75,22 +75,22 @@ def config_get(key: str):
 @click.argument("key")
 @click.argument("value")
 def config_set(key: str, value: str):
-    from torrra.core.context import config
+    from torrra.core.context import config as cfg
     from torrra.core.exceptions import ConfigError
 
     try:
-        config.set(key, value)
+        cfg.set(key, value)
     except ConfigError as e:
         click.secho(e, fg="red", err=True)
 
 
 @config.command(name="list", help="List all configurations.")
 def config_list():
-    from torrra.core.context import config
+    from torrra.core.context import config as cfg
     from torrra.core.exceptions import ConfigError
 
     try:
-        click.echo("\n".join(config.list()))
+        click.echo("\n".join(cfg.list()))
     except ConfigError as e:
         click.secho(e, fg="red", err=True)
 

--- a/src/torrra/__main__.py
+++ b/src/torrra/__main__.py
@@ -8,8 +8,9 @@ from torrra._version import __version__
 @click.pass_context
 def cli(ctx: click.Context) -> None:
     if not ctx.invoked_subcommand:
-        # run app
-        pass
+        from torrra.utils.indexer import auto_detect_indexer_and_run
+
+        auto_detect_indexer_and_run()
 
 
 # ========== INDEXERS ==========

--- a/src/torrra/utils/helpers.py
+++ b/src/torrra/utils/helpers.py
@@ -4,3 +4,17 @@ def human_readable_size(size_bytes: float) -> str:
             return f"{size_bytes:.2f} {unit}"
         size_bytes /= 1024.0
     return f"{size_bytes:.2f} PB"
+
+
+def lazy_import(dotted_path: str):
+    import importlib
+
+    import click
+
+    try:
+        module_path, obj_name = dotted_path.rsplit(".", 1)
+        module = importlib.import_module(module_path)
+        return getattr(module, obj_name)
+    except (ModuleNotFoundError, AttributeError) as e:
+        click.secho(f"failed to load: {dotted_path}\n{e}", fg="red", err=True)
+        raise

--- a/src/torrra/utils/indexer.py
+++ b/src/torrra/utils/indexer.py
@@ -59,7 +59,7 @@ def handle_indexer_command(
         app.run()
 
 
-def auto_detect_indexer_and_run():
+def auto_detect_indexer_and_run(no_cache: bool):
     from torrra.core.context import config
     from torrra.core.exceptions import ConfigError
 
@@ -77,7 +77,7 @@ def auto_detect_indexer_and_run():
             connection_error_cls_str=f"torrra.core.exceptions.{default_indexer.title()}ConnectionError",
             url=url,
             api_key=api_key,
-            no_cache=False,
+            no_cache=no_cache,
         )
     except ConfigError as e:
         click.secho(f"{e}\ncheck your configuration file.", fg="red", err=True)


### PR DESCRIPTION
If no subcommand is specified (i.e `torrra`),
run the default indexer specified at `config.toml`:
```toml
[indexers]
default = "jackett"

[indexers.jackett]
url = "..."
api_key = "..."
```

Related to:
 - #57 
 - #54 