### PR TITLE
feat: dottorrent file support

### DIFF
--- a/src/torrra/indexers/jackett.py
+++ b/src/torrra/indexers/jackett.py
@@ -73,5 +73,5 @@ class JackettIndexer:
             seeders=r.get("Seeders", 0),
             leechers=r.get("Peers", 0),
             source=r.get("Tracker", "unknown"),
-            magnet_uri=r.get("MagnetUri", None),
+            magnet_uri=r.get("MagnetUri") or r.get("Link"),
         )

--- a/src/torrra/indexers/jackett.py
+++ b/src/torrra/indexers/jackett.py
@@ -68,7 +68,7 @@ class JackettIndexer:
 
     def _normalize_result(self, r: dict[str, Any]) -> Torrent:
         return Torrent(
-            title=r.get("Title", ""),
+            title=r.get("Title", "unknown"),
             size=r.get("Size", 0),
             seeders=r.get("Seeders", 0),
             leechers=r.get("Peers", 0),

--- a/src/torrra/indexers/prowlarr.py
+++ b/src/torrra/indexers/prowlarr.py
@@ -65,10 +65,10 @@ class ProwlarrIndexer:
 
     def _normalize_result(self, r: dict[str, Any]) -> Torrent:
         return Torrent(
-            title=r.get("title", ""),
+            title=r.get("title", "unknown"),
             size=r.get("size", 0),
             seeders=r.get("seeders", 0),
             leechers=r.get("leechers", 0),
             source=r.get("indexer", "unknown"),
-            magnet_uri=r.get("magnetUrl", None),
+            magnet_uri=r.get("magnetUrl") or r.get("downloadUrl"),
         )

--- a/src/torrra/screens/search.py
+++ b/src/torrra/screens/search.py
@@ -232,12 +232,9 @@ class SearchScreen(Screen[None]):
 
         if isinstance(resolved, str) and resolved.startswith("magnet:"):
             self.lt_handle = lt.add_magnet_uri(self.lt_session, resolved, params)
-        elif isinstance(resolved, lt.torrent_info):
+        else:
             params["ti"] = resolved
             self.lt_handle = self.lt_session.add_torrent(params)
-        else:
-            # if none, not possibble
-            return  # make linter happie
 
         while not self.lt_handle.has_metadata():
             time.sleep(0.5)


### PR DESCRIPTION
Properly resolve `magnet uri` or `torrent info` from a download/redirect url.
In case of download url, saves the torrent link temporarily in fs and gets deleted after getting torrent.

Fix for #82 