### PR TITLE
fix: do not cache empty results

### DIFF
--- a/src/torrra/indexers/jackett.py
+++ b/src/torrra/indexers/jackett.py
@@ -29,7 +29,7 @@ class JackettIndexer:
             res = resp.json().get("Results", [])
             torrents = [self._normalize_result(r) for r in res]
 
-        if use_cache:
+        if use_cache and torrents:
             set_cache(key, [t.to_dict() for t in torrents])
 
         return torrents


### PR DESCRIPTION
Potential fix for most of the upstream issues which shows empty result.
This prevents caching `empty` results.