### PR TITLE
feat: config-based cache_ttl value

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,7 @@ remember_last_path = true                     # If true, torrra will reuse the l
 download_in_external_client = false           # If true, opens magnet links in an external torrent client instead of downloading the .torrent file.
 theme = "textual-dark"                        # Theme for the application (e.g., "textual-dark", "textual-light", etc.).
 use_cache = true                              # If true, search results will be cached to speed up subsequent searches.
+cache_ttl = 300                               # The time in seconds that search results will be cached.
 seed_ratio = 1.5                              # Target upload/download ratio. Seeding stops when reached. Omit or set None for infinite seeding.
 
 [indexers]

--- a/src/torrra/core/cache.py
+++ b/src/torrra/core/cache.py
@@ -5,7 +5,8 @@ from typing import Any, override
 from diskcache import Cache as _Cache
 from platformdirs import user_cache_dir
 
-from torrra.core.constants import CACHE_TTL
+from torrra.core.config import config
+from torrra.core.constants import DEFAULT_CACHE_TTL
 
 
 class Cache(_Cache):
@@ -19,7 +20,7 @@ class Cache(_Cache):
         tag: Any = None,
         retry: bool = False,
     ):
-        expire = CACHE_TTL  # TODO: load from config
+        expire = config.get("general.cache_ttl", DEFAULT_CACHE_TTL)
         return super().set(key, value, expire, read, tag, retry)
 
     def make_key(self, prefix: str, query: str) -> str:

--- a/src/torrra/core/config.py
+++ b/src/torrra/core/config.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import tomli_w
 from platformdirs import user_config_dir, user_downloads_dir
 
+from torrra.core.constants import DEFAULT_CACHE_TTL
 from torrra.core.exceptions import ConfigError
 
 CONFIG_DIR = Path(user_config_dir("torrra"))
@@ -112,6 +113,7 @@ class Config:
                 "download_in_external_client": False,
                 "theme": "textual-dark",
                 "use_cache": True,
+                "cache_ttl": DEFAULT_CACHE_TTL,
                 "seed_ratio": None,
             }
         }

--- a/src/torrra/core/constants.py
+++ b/src/torrra/core/constants.py
@@ -1,1 +1,1 @@
-CACHE_TTL = 300  # 5 mins
+DEFAULT_CACHE_TTL = 300  # 5 mins


### PR DESCRIPTION
introduces `cache_ttl` in `config.toml` (defaulting to 300 seconds) to control cache expiry.
updates `cache.py` to use this new configuration value.
renames `CACHE_TTL` to `DEFAULT_CACHE_TTL` for better clarity and uses it in `_create_default_config`.
documentation in `configuration.md` has been updated accordingly.