### PR TITLE
build: migrate from hatch to uv-build

### DIFF
--- a/pkgbuild-template/torrra/PKGBUILD
+++ b/pkgbuild-template/torrra/PKGBUILD
@@ -21,7 +21,7 @@ makedepends=(
     "python-build"
     "python-installer"
     "python-wheel"
-    "python-hatchling"
+    "python-uv-build"
 )
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,5 +75,5 @@ reportMissingTypeStubs = "none"
 reportUnknownMemberType = "none"
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv-build>=0.8.20,<0.9.0"]
+build-backend = "uv_build"


### PR DESCRIPTION
This PR migrates the project's build system from `hatchling` to `uv-build`.
The following changes have been made:
- The `[build-system]` in `pyproject.toml` has been updated to use `uv-build`.
- The AUR `PKGBUILD` template has been updated to use `python-uv-build` as a build dependency instead of `python-hatchling`.