### PR TITLE
fix: pyinstaller include lazy imported modules

### DIFF
--- a/src/torrra/__main__.py
+++ b/src/torrra/__main__.py
@@ -42,7 +42,6 @@ def jackett(url: str | None, api_key: str | None, no_cache: bool) -> None:
     run_with_indexer(
         name="jackett",
         indexer_cls_str="torrra.indexers.jackett.JackettIndexer",
-        connection_error_cls_str="torrra.core.exceptions.JackettConnectionError",
         url=url,
         api_key=api_key,
         no_cache=no_cache,
@@ -60,7 +59,6 @@ def prowlarr(url: str | None, api_key: str | None, no_cache: bool):
     run_with_indexer(
         name="prowlarr",
         indexer_cls_str="torrra.indexers.prowlarr.ProwlarrIndexer",
-        connection_error_cls_str="torrra.core.exceptions.ProwlarrConnectionError",
         url=url,
         api_key=api_key,
         no_cache=no_cache,

--- a/src/torrra/core/exceptions.py
+++ b/src/torrra/core/exceptions.py
@@ -1,16 +1,10 @@
 class ConfigError(Exception):
-    """Custom error for config key issues."""
+    """Config error."""
 
     pass
 
 
-class JackettConnectionError(Exception):
-    """Raised when Jackett is unreachable or misconfigured."""
-
-    pass
-
-
-class ProwlarrConnectionError(Exception):
-    """Raised when Prowlarr is unreachable or misconfigured."""
+class IndexerError(Exception):
+    """Indexer error."""
 
     pass

--- a/src/torrra/indexers/jackett.py
+++ b/src/torrra/indexers/jackett.py
@@ -4,7 +4,7 @@ import httpx
 
 from torrra._types import Torrent, TorrentDict
 from torrra.core.cache import cache
-from torrra.core.exceptions import JackettConnectionError
+from torrra.core.exceptions import IndexerError
 from torrra.indexers.base import BaseIndexer
 
 
@@ -43,7 +43,7 @@ class JackettIndexer(BaseIndexer):
                 return True
 
             except httpx.RequestError:
-                raise JackettConnectionError(
+                raise IndexerError(
                     "could not connect to jackett server\n"
                     + "please make sure jackett server is running and the url is correct"
                 )
@@ -52,14 +52,14 @@ class JackettIndexer(BaseIndexer):
                 status_code = e.response.status_code
 
                 if status_code == 401:
-                    raise JackettConnectionError(
+                    raise IndexerError(
                         "invalid jackett server api key\n"
                         + "double-check the api key you provided"
                     )
                 elif status_code == 500 and "nonexistent_indexer" in e.response.text:
                     return True
                 else:
-                    raise JackettConnectionError(
+                    raise IndexerError(
                         f"jackett server returned http {status_code}\n"
                         + "unexpected response from jackett server. please verify your setup"
                     )

--- a/src/torrra/indexers/prowlarr.py
+++ b/src/torrra/indexers/prowlarr.py
@@ -4,7 +4,7 @@ import httpx
 
 from torrra._types import Torrent, TorrentDict
 from torrra.core.cache import cache
-from torrra.core.exceptions import ProwlarrConnectionError
+from torrra.core.exceptions import IndexerError
 from torrra.indexers.base import BaseIndexer
 
 
@@ -42,7 +42,7 @@ class ProwlarrIndexer(BaseIndexer):
                 return True
 
             except httpx.RequestError:
-                raise ProwlarrConnectionError(
+                raise IndexerError(
                     "could not connect to prowlarr server\n"
                     + "please make sure prowlarr server is running and the url is correct"
                 )
@@ -51,12 +51,12 @@ class ProwlarrIndexer(BaseIndexer):
                 status_code = e.response.status_code
 
                 if status_code == 401:
-                    raise ProwlarrConnectionError(
+                    raise IndexerError(
                         "invalid prowlarr server api key\n"
                         + "double-check the api key you provided"
                     )
                 else:
-                    raise ProwlarrConnectionError(
+                    raise IndexerError(
                         f"prowlarr server returned http {status_code}\n"
                         + "unexpected response from prowlarr server. please verify your setup"
                     )

--- a/torrra.spec
+++ b/torrra.spec
@@ -3,17 +3,20 @@ import os
 from glob import glob
 
 
-css_files = glob('src/torrra/**/*.css', recursive=True)
+css_files = glob("src/torrra/**/*.css", recursive=True)
 additional_datas = [
-    (f, os.path.dirname(f).replace('src/', '')) for f in css_files
+    (f, os.path.dirname(f).replace("src/", "")) for f in css_files
 ]
 
 a = Analysis(
-    ['src/torrra/__main__.py'],
+    ["src/torrra/__main__.py"],
     pathex=[],
     binaries=[],
     datas=additional_datas,
-    hiddenimports=[],
+    hiddenimports=[
+      "torrra.indexers.jackett",
+      "torrra.indexers.prowlarr",
+    ],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
@@ -21,6 +24,7 @@ a = Analysis(
     noarchive=False,
     optimize=0,
 )
+
 pyz = PYZ(a.pure)
 
 exe = EXE(
@@ -29,7 +33,7 @@ exe = EXE(
     a.binaries,
     a.datas,
     [],
-    name='torrra',
+    name="torrra",
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,


### PR DESCRIPTION
fixes #150 

some indexer modules (e.g., jackett, prowlarr) are imported lazily at runtime. the binary previously failed to locate these modules, causing a crash during startup.

added explicit hidden imports for dynamically imported modules to the spec (or build configuration) to ensure `pyinstaller` bundles them:
```spec
a = Analysis(
    ["src/torrra/__main__.py"],
    ...
    hiddenimports=[
      "torrra.indexers.jackett",
      "torrra.indexers.prowlarr",
    ],
    ...
```