### PR TITLE
fix: update uv-build dependency range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,5 +75,5 @@ reportMissingTypeStubs = "none"
 reportUnknownMemberType = "none"
 
 [build-system]
-requires = ["uv-build>=0.8.20,<0.9.0"]
+requires = ["uv-build>=0.8.19,<0.9.9"]
 build-backend = "uv_build"


### PR DESCRIPTION
fix `PKGBUILD` build process by correcting source extraction and build directory handling, and update `uv-build` version range to ensure proper dependency resolution and compatibility across arch environments.

```console
==> Making package: torrra 1.3.1-1 (Thursday 13 November 2025 09:34:30 PM)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Found torrra-1.3.1.tar.gz
==> Validating source files with sha256sums...
    torrra-1.3.1.tar.gz ... Skipped
==> Extracting sources...
  -> Extracting torrra-1.3.1.tar.gz with bsdtar
==> Removing existing $pkgdir/ directory...
==> Starting build()...
* Getting build dependencies for wheel...

ERROR Missing dependencies:
	uv-build<0.9.0,>=0.8.20
==> ERROR: A failure occurred in build().
    Aborting...
```