### PR TITLE
fix: config.get raises error with default none

### DIFF
--- a/src/torrra/core/config.py
+++ b/src/torrra/core/config.py
@@ -14,13 +14,17 @@ from torrra.core.exceptions import ConfigError
 CONFIG_DIR = Path(user_config_dir("torrra"))
 CONFIG_FILE = CONFIG_DIR / "config.toml"
 
+# sentinel value used for robust
+# config.get(..., default=...) value check
+_sentinel = object()
+
 
 class Config:
     def __init__(self) -> None:
         self.config: dict[str, Any] = {}
         self._load_config()
 
-    def get(self, key_path: str, default: Any | None = None) -> Any:
+    def get(self, key_path: str, default: Any | None = _sentinel) -> Any:
         keys = key_path.split(".")
         current = self.config
 
@@ -35,7 +39,7 @@ class Config:
             return current
 
         except (KeyError, TypeError):
-            if default is not None:
+            if default is not _sentinel:
                 return default
 
             if len(keys) > 1:


### PR DESCRIPTION
this PR fixes a bug in the `Config.get` method where it would incorrectly raise a `ConfigError` when a missing key was queried with an explicit `default=None`.

the previous implementation could not distinguish between a `None` value that was explicitly passed and the absence of a default argument.

this has been resolved by refactoring the `get` method to use a sentinel object. this allows the method to reliably determine if a default value was provided by the caller and return it correctly, making the configuration handling more robust.