### PR TITLE
ci: add python 3.14 version to matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 jobs:
-  publish_pypi:
+  pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     environment:
@@ -18,11 +18,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: ".python-version"
+
       - name: Install uv and setup the python version
         uses: astral-sh/setup-uv@v7
-
-      - name: Install the project
-        run: uv sync --all-groups
+        with:
+          enable-cache: true
 
       - name: Build wheel
         run: uv build
@@ -30,7 +34,7 @@ jobs:
       - name: Publish package
         run: uv publish
 
-  publish_docker:
+  docker:
     name: Publish to Docker Hub
     runs-on: ubuntu-latest
     environment:
@@ -72,7 +76,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os:
+          - "ubuntu-latest"
+          - "windows-latest"
+          - "macos-latest"
     permissions:
       contents: write
     steps:
@@ -84,14 +91,18 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Install uv and setup the python version
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .
-          pip install pyinstaller
+          uv sync --locked
+          uv pip install pyinstaller
 
       - name: Build standalone binary
-        run: pyinstaller torrra.spec
+        run: uv run pyinstaller torrra.spec
 
       - name: Rename binary by platform
         shell: bash
@@ -112,7 +123,7 @@ jobs:
         with:
           files: dist-out/*
 
-  publish_aur:
+  aur:
     name: Publish to AUR
     needs: build_and_attach_bin
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Communications :: File Sharing",
     "Topic :: Terminals",
     "Topic :: Terminals :: Terminal Emulators/X Terminals",


### PR DESCRIPTION
Add `3.14` to test runner matrix.
And add "3.14" to `classifiers` in `pyproject.toml`.