### PR TITLE
fix: include app.tcss in pyinstaller build

### DIFF
--- a/torrra.spec
+++ b/torrra.spec
@@ -1,18 +1,12 @@
 # -*- mode: python ; coding: utf-8 -*-
-import os
-from glob import glob
-
-
-css_files = glob("src/torrra/**/*.css", recursive=True)
-additional_datas = [
-    (f, os.path.dirname(f).replace("src/", "")) for f in css_files
-]
 
 a = Analysis(
     ["src/torrra/__main__.py"],
     pathex=[],
     binaries=[],
-    datas=additional_datas,
+    datas=[
+      ("src/torrra/app.tcss", "torrra"),
+    ],
     hiddenimports=[
       "torrra.indexers.jackett",
       "torrra.indexers.prowlarr",


### PR DESCRIPTION
Fixes #168 
Added `app.tcss` file in `datas` field in the `torrra.spec` file.