### PR TITLE
test: fix test_theme_selector use mock config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -8,6 +9,15 @@ from torrra._types import Indexer
 from torrra.app import TorrraApp
 from torrra.core import config as config_module
 from torrra.core.config import Config
+
+
+@pytest.fixture
+def fast_sleep(monkeypatch: pytest.MonkeyPatch):
+    # patch asyncio sleep to almost wake up instantly
+    async def no_sleep(_duration: int):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
 
 
 @pytest.fixture

--- a/tests/screens/test_theme_selector.py
+++ b/tests/screens/test_theme_selector.py
@@ -40,7 +40,14 @@ async def test_theme_selector_navigation_with_j_and_k(app: TorrraApp):
         assert list_view.index == initial_index
 
 
-async def test_theme_selector_select_theme_with_enter(app: TorrraApp):
+@pytest.mark.usefixtures("fast_sleep")
+async def test_theme_selector_select_theme_with_enter(
+    app: TorrraApp, mock_config: Config, monkeypatch: pytest.MonkeyPatch
+):
+    # patch config instance used by theme_selector module
+    # with mock_config
+    monkeypatch.setattr("torrra.screens.theme_selector.config", mock_config)
+
     async with app.run_test() as pilot:
         await pilot.press("ctrl+t")
         assert isinstance(app.screen, ThemeSelectorScreen)
@@ -50,7 +57,7 @@ async def test_theme_selector_select_theme_with_enter(app: TorrraApp):
 
         # navigate and wait for preview
         list_view.index = 1
-        await pilot.pause(0.6)
+        await pilot.pause()
         assert app.theme == target_theme
 
         await pilot.press("enter")
@@ -58,6 +65,7 @@ async def test_theme_selector_select_theme_with_enter(app: TorrraApp):
 
         assert len(app.screen_stack) == 2  # default + welcome screen
         assert app.theme == target_theme
+        assert mock_config.get("general.theme") == target_theme
 
 
 async def test_theme_selector_cancel_selection_with_escape(


### PR DESCRIPTION
Patch `torrra.screens.theme_selector.config` with `mock_config` fixture to prevent modifying original config file and isolate test config file. also add `mock_config.get()` test case on theme selection.

Instead of delaying test for theme preview to update, patch `asyncio.sleep` method to wake up instantly.
This avoids delayed test cases.