### PR TITLE
fix: resolve libtorrent 2.x deprecation warning for add_magnet_uri 

### DIFF
--- a/src/torrra/core/download.py
+++ b/src/torrra/core/download.py
@@ -28,11 +28,11 @@ class DownloadManager:
             return
 
         # Parse the magnet URI into torrent parameters (modern libtorrent 2.x API)
-        atp = lt.parse_magnet_uri(magnet_uri)       
+        atp = lt.parse_magnet_uri(magnet_uri)
         atp.save_path = get_config().get("general.download_path")
         if is_paused:
             atp.flags |= lt.torrent_flags.paused
-        
+
         # Add the torrent to the session and start tracking
         self.torrents[magnet_uri] = self.session.add_torrent(atp)
 


### PR DESCRIPTION
fixes: #194 