### PR TITLE
feat: better default indexer error message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,13 +78,9 @@ dev = [
     "textual-dev>=1.7.0",
 ]
 
-[tool.basedpyright]
-pythonVersion = "3.10"
-reportUnusedCallResult = "none"
-reportAny = "none"
-reportExplicitAny = "none"
-reportMissingTypeStubs = "none"
-reportUnknownMemberType = "none"
+
+[tool.ty.environment]
+python-version = "3.10"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/torrra/utils/indexer.py
+++ b/src/torrra/utils/indexer.py
@@ -35,8 +35,14 @@ def run_with_indexer(
         try:
             url = config.get(f"indexers.{name}.url")
             api_key = config.get(f"indexers.{name}.api_key")
-        except ConfigError as e:
-            click.secho(f"{e}\ncheck your configuration file.", fg="red", err=True)
+        except ConfigError:
+            message = (
+                f"Indexer '{name}' is not configured.\n"
+                "Please set it in your configuration file, or provide --url and --api-key.\n"
+                "For more details, see the documentation: "
+                "https://torrra.readthedocs.io/en/latest/configuration.html"
+            )
+            click.secho(message, fg="red", err=True)
             return
 
     click.secho(f"connecting to {name} server at {url}", fg="cyan")
@@ -97,8 +103,16 @@ def run_with_default_indexer(
                 "https://torrra.readthedocs.io/en/latest/configuration.html"
             )
 
-        url = config.get(f"indexers.{default_indexer}.url")
-        api_key = config.get(f"indexers.{default_indexer}.api_key")
+        try:
+            url = config.get(f"indexers.{default_indexer}.url")
+            api_key = config.get(f"indexers.{default_indexer}.api_key")
+        except ConfigError:
+            raise ConfigError(
+                f"Default indexer '{default_indexer}' is not configured properly. "
+                "Please make sure 'url' and 'api_key' are set.\n"
+                "For more details, see the documentation: "
+                "https://torrra.readthedocs.io/en/latest/configuration.html"
+            )
 
         run_with_indexer(
             name=cast(IndexerName, default_indexer),
@@ -112,6 +126,3 @@ def run_with_default_indexer(
         # the specific error message for default indexer is now raised within the try block
         # so, we just print the error message from the exception
         click.secho(str(e), fg="red", err=True)
-        # add a note about checking configuration file if it's not the specific friendly message
-        if "Default indexer is not configured" not in str(e):
-            click.secho("check your configuration file.", fg="red", err=True)


### PR DESCRIPTION
Instead of just showing "key_path" not found error message if user tries to access: `torrra` root command,
show more human friendly message which includes docs link.