### PR TITLE
chore: replace hardcoded version with __version__ reference

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,10 +6,12 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+from torrra._version import __version__
+
 project = "Torrra"
 copyright = "2025, stabldev"
 author = "stabldev"
-release = "2.0.4"
+release = __version__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
This PR replaces the hardcoded version string with a dynamic reference to `__version__`. 

Closes #203 