### PR TITLE
fix: local torrent is_paused state

### DIFF
--- a/src/torrra/core/download.py
+++ b/src/torrra/core/download.py
@@ -25,7 +25,20 @@ class DownloadManager:
 
     def add_torrent(self, magnet_uri: str, is_paused: bool = False) -> None:
         if magnet_uri in self.torrents:
-            return
+            # Torrent already exists, update paused state if needed
+            handle = self.torrents[magnet_uri]
+            if not handle.is_valid():
+                # If handle is invalid, remove it and add the torrent fresh
+                del self.torrents[magnet_uri]
+            else:
+                # Check current paused state and update if different
+                current_status = handle.status()
+                is_currently_paused = (
+                    current_status.flags & lt.torrent_flags.paused
+                ) != 0
+                if is_currently_paused != is_paused:
+                    handle.pause() if is_paused else handle.resume()
+                return
 
         # Parse the magnet URI into torrent parameters (modern libtorrent 2.x API)
         atp = lt.parse_magnet_uri(magnet_uri)


### PR DESCRIPTION
Fixed an issue where paused torrents would resume when switching screens or restarting the app. The add_torrent method now properly updates the paused state of existing torrents instead of ignoring them.

   - Modified add_torrent in DownloadManager to check and update paused state when torrent already exists
   - Ensures database state matches actual torrent state when switching between UI screens