### PR TITLE
feat: add remaining time (ETA) display in torrent details panel

### DIFF
--- a/src/torrra/_types.py
+++ b/src/torrra/_types.py
@@ -26,6 +26,8 @@ class TorrentStatus(TypedDict):
     seeders: int
     leechers: int
     is_paused: bool
+    eta: float | None
+    is_seeding: bool
 
 
 class TorrentRecord(TypedDict):

--- a/src/torrra/core/download.py
+++ b/src/torrra/core/download.py
@@ -93,6 +93,18 @@ class DownloadManager:
             return None
 
         s = handle.status()
+        is_seeding = (
+            s.is_seeding
+            or s.is_finished
+            or s.state == lt.torrent_status.states.seeding
+            or s.state == lt.torrent_status.states.finished
+        )
+        eta: float | None = None
+        if not is_seeding:
+            remaining_bytes = s.total_wanted - s.total_wanted_done
+            if remaining_bytes > 0 and s.download_rate > 0:
+                eta = remaining_bytes / s.download_rate
+
         return TorrentStatus(
             state=s.state,
             progress=s.progress * 100,
@@ -101,6 +113,8 @@ class DownloadManager:
             seeders=s.num_seeds,
             leechers=s.num_peers,
             is_paused=(s.flags & lt.torrent_flags.paused) != 0,
+            eta=eta,
+            is_seeding=is_seeding,
         )
 
     def get_torrent_state_text(self, status: TorrentStatus, short: bool = False) -> str:

--- a/src/torrra/utils/helpers.py
+++ b/src/torrra/utils/helpers.py
@@ -23,6 +23,27 @@ def human_readable_size(size_bytes: float, short: bool = False) -> str:
     return f"{int(size_bytes)}P"
 
 
+def human_readable_eta(seconds: float | None, is_seeding: bool = False) -> str:
+    if is_seeding or seconds is None or seconds < 0 or seconds == float("inf"):
+        return "∞"
+
+    total_seconds = int(seconds)
+    if total_seconds == 0:
+        return "0s"
+
+    days, remainder = divmod(total_seconds, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, secs = divmod(remainder, 60)
+
+    if days > 0:
+        return f"{days}d {hours}h" if hours > 0 else f"{days}d"
+    if hours > 0:
+        return f"{hours}h {minutes}m" if minutes > 0 else f"{hours}h"
+    if minutes > 0:
+        return f"{minutes}m {secs}s" if secs > 0 else f"{minutes}m"
+    return f"{secs}s"
+
+
 def lazy_import(dotted_path: str):
     import importlib
 

--- a/src/torrra/widgets/details_panel.py
+++ b/src/torrra/widgets/details_panel.py
@@ -20,7 +20,7 @@ class DetailsPanel(Vertical):
     def compose(self) -> ComposeResult:
         yield Static()
         if self.show_progress_bar:
-            yield ProgressBar(total=100)
+            yield ProgressBar(total=100, show_eta=False)
 
     def on_mount(self) -> None:
         self._content_widget = self.query_one(Static)

--- a/src/torrra/widgets/downloads.py
+++ b/src/torrra/widgets/downloads.py
@@ -7,7 +7,7 @@ from typing_extensions import override
 from torrra._types import TorrentRecord, TorrentStatus
 from torrra.core.download import DownloadManager, get_download_manager
 from torrra.core.torrent import TorrentManager, get_torrent_manager
-from torrra.utils.helpers import human_readable_size
+from torrra.utils.helpers import human_readable_eta, human_readable_size
 from torrra.widgets.data_table import AutoResizingDataTable
 from torrra.widgets.details_panel import DetailsPanel
 
@@ -247,11 +247,12 @@ class DownloadsContent(Vertical):
         size = human_readable_size(float(current_torrent["size"]))
         up_speed = f"{human_readable_size(status['up_speed'])}/s"
         down_speed = f"{human_readable_size(status['down_speed'])}/s"
+        eta_text = human_readable_eta(status["eta"], is_seeding=status["is_seeding"])
 
         details = f"""
 [b]{current_torrent["title"]}[/b]
 [b]Size:[/b] {size} - [b]Status:[/b] {state_text} - [b]Source:[/b] {current_torrent["source"]}
-[b]S/L:[/b] {status["seeders"]}/{status["leechers"]} - [b]Up:[/b] {up_speed} - [b]Down:[/b] {down_speed}
+[b]S/L:[/b] {status["seeders"]}/{status["leechers"]} - [b]Up:[/b] {up_speed} - [b]Down:[/b] {down_speed} - [b]ETA:[/b] {eta_text}
 
 [dim]Press 'p' to pause/resume, 'd' to delete, 'D' to delete w/ data, or 'esc' to close.[/dim]
 """

--- a/tests/test_utils_helpers.py
+++ b/tests/test_utils_helpers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from torrra.utils.helpers import human_readable_size, lazy_import
+from torrra.utils.helpers import human_readable_eta, human_readable_size, lazy_import
 
 
 def test_human_readable_size():
@@ -9,6 +9,21 @@ def test_human_readable_size():
     assert human_readable_size(1500) == "1.46 KB"
     assert human_readable_size(1024 * 1024 * 5) == "5.00 MB"
     assert human_readable_size(1024**4) == "1.00 TB"
+
+
+def test_human_readable_eta():
+    assert human_readable_eta(None) == "∞"
+    assert human_readable_eta(None, is_seeding=True) == "∞"
+    assert human_readable_eta(100, is_seeding=True) == "∞"
+    assert human_readable_eta(0) == "0s"
+    assert human_readable_eta(45) == "45s"
+    assert human_readable_eta(60) == "1m"
+    assert human_readable_eta(125) == "2m 5s"
+    assert human_readable_eta(3600) == "1h"
+    assert human_readable_eta(3665) == "1h 1m"
+    assert human_readable_eta(86400) == "1d"
+    assert human_readable_eta(90000) == "1d 1h"
+    assert human_readable_eta(-10) == "∞"
 
 
 def test_lazy_import():


### PR DESCRIPTION
Partially addresses #284.

## Summary
Adds custom estimated remaining time (ETA) calculation and display in the torrent details panel under the Downloads section.

- Added \human_readable_eta\ helper function in \	orrra.utils.helpers\ to format seconds into readable strings (\45s\, \2m 5s\, \1h 10m\) or \∞\ when seeding, paused, or when speed is zero.
- Updated \TorrentStatus\ and \DownloadManager.get_torrent_status()\ to calculate ETA based on remaining bytes and download rate.
- Displayed \ETA\ in the details panel next to upload/download speeds.
- Disabled default \show_eta\ on the \ProgressBar\ in favor of our custom ETA calculation.
- Added unit tests for \human_readable_eta\.