### PR TITLE
fix: coerce null numeric fields returned by indexers

### DIFF
--- a/src/torrra/indexers/jackett.py
+++ b/src/torrra/indexers/jackett.py
@@ -82,11 +82,14 @@ class JackettIndexer(BaseIndexer):
 
     @override
     def _normalize_result(self, r: dict[str, Any]) -> Torrent:
+        # `or 0` rather than a get() default: jackett sends "Peers": null for
+        # some trackers, and get("Peers", 0) returns the null because the key
+        # is present. that None renders as "None" and breaks any comparison.
         return Torrent(
-            title=r.get("Title", "unknown"),
-            size=r.get("Size", 0),
-            seeders=r.get("Seeders", 0),
-            leechers=r.get("Peers", 0),
-            source=r.get("Tracker", "unknown"),
+            title=r.get("Title") or "unknown",
+            size=r.get("Size") or 0,
+            seeders=r.get("Seeders") or 0,
+            leechers=r.get("Peers") or 0,
+            source=r.get("Tracker") or "unknown",
             magnet_uri=r.get("MagnetUri") or r["Link"],
         )

--- a/src/torrra/indexers/prowlarr.py
+++ b/src/torrra/indexers/prowlarr.py
@@ -80,11 +80,14 @@ class ProwlarrIndexer(BaseIndexer):
 
     @override
     def _normalize_result(self, r: dict[str, Any]) -> Torrent:
+        # `or 0` rather than a get() default: prowlarr reports null seeders and
+        # leechers for indexers that don't publish them, and get(key, 0) keeps
+        # the null because the key is present
         return Torrent(
-            title=r.get("title", "unknown"),
-            size=r.get("size", 0),
-            seeders=r.get("seeders", 0),
-            leechers=r.get("leechers", 0),
-            source=r.get("indexer", "unknown"),
+            title=r.get("title") or "unknown",
+            size=r.get("size") or 0,
+            seeders=r.get("seeders") or 0,
+            leechers=r.get("leechers") or 0,
+            source=r.get("indexer") or "unknown",
             magnet_uri=r.get("magnetUrl") or r["downloadUrl"],
         )

--- a/tests/test_indexers.py
+++ b/tests/test_indexers.py
@@ -35,6 +35,37 @@ MOCK_SEARCH_RESPONSE = {
 }
 
 
+# indexers annotate these fields as ints but send explicit nulls: jackett
+# reports "Peers": null for several trackers, and prowlarr omits counts for
+# indexers that don't publish them
+MOCK_NULL_RESPONSE = {
+    "jackett": {
+        "Results": [
+            {
+                "Title": None,
+                "Size": None,
+                "Seeders": None,
+                "Peers": None,
+                "Tracker": None,
+                "MagnetUri": None,
+                "Link": "http://mock.indexer.url/dl/mock",
+            }
+        ]
+    },
+    "prowlarr": [
+        {
+            "title": None,
+            "size": None,
+            "seeders": None,
+            "leechers": None,
+            "indexer": None,
+            "magnetUrl": None,
+            "downloadUrl": "http://mock.indexer.url/dl/mock",
+        }
+    ],
+}
+
+
 @pytest.fixture(params=[JackettIndexer, ProwlarrIndexer])
 def indexer(request: pytest.FixtureRequest) -> BaseIndexer:
     return request.param(url=MOCK_API_URL, api_key=MOCK_API_KEY)
@@ -69,3 +100,31 @@ async def test_healthcheck(indexer: BaseIndexer) -> None:
     respx.get(url).mock(Response(200))
 
     assert await indexer.healthcheck() is True
+
+
+@respx.mock
+async def test_null_fields_are_coerced(indexer: BaseIndexer) -> None:
+    """A null in a numeric field must not reach Torrent.
+
+    dict.get(key, default) returns the null when the key is present, so the
+    defaults these normalizers were written with never fired.
+    """
+    indexer_name = indexer.__class__.__name__.removesuffix("Indexer").lower()
+    respx.get(indexer.get_search_url()).mock(
+        Response(200, json=MOCK_NULL_RESPONSE[indexer_name])
+    )
+
+    results = await indexer.search("anything", use_cache=False)
+
+    assert results is not None
+    r = results[0]
+    assert r.seeders == 0
+    assert r.leechers == 0
+    assert r.size == 0
+    assert r.title == "unknown"
+    assert r.source == "unknown"
+    # a null magnet still falls back to the download link
+    assert r.magnet_uri == "http://mock.indexer.url/dl/mock"
+
+    # the S:L cell the results table builds must not read "None"
+    assert f"{r.seeders!s}:{r.leechers!s}" == "0:0"


### PR DESCRIPTION
Jackett returns `"Peers": null` for trackers that publish no peer counts, and Prowlarr does the same for seeders and leechers. That `None` reaches `Torrent` despite the `int` annotation, so affected rows render as `1:None` in the S:L column and any comparison against the field raises `TypeError`.

The existing `dict.get(key, 0)` default doesn't help here, because the key *is* present — it just holds `null`. A default only fires on a missing key. Switching to `or default` means a null lands on the same fallback an absent key would.

I measured this against a real Jackett instance: 75 of 6,257 results across three queries came back with a null `Peers`, from HDRTorrent, RedeTorrent and ApacheTorrent. It isn't exotic — you just don't see it with a tracker set that happens to report peers.

Both normalizers are covered, plus a test that fails on the current code.
