### PR TITLE
fix: size table columns to their content so cells aren't clipped

### DIFF
--- a/src/torrra/widgets/data_table.py
+++ b/src/torrra/widgets/data_table.py
@@ -3,6 +3,7 @@ from typing import Any, ClassVar, TypeVar
 
 from textual.binding import Binding, BindingType
 from textual.reactive import reactive
+from textual.render import measure
 from textual.widgets import DataTable
 from textual.widgets.data_table import ColumnKey
 
@@ -24,6 +25,8 @@ class AutoResizingDataTable(DataTable[T]):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._last_g_press: float = 0
+        # width each column was declared with, kept as a floor by fit_columns
+        self._min_col_widths: dict[ColumnKey, int] = {}
 
     def key_g(self) -> None:
         current_time = time.time()
@@ -37,12 +40,50 @@ class AutoResizingDataTable(DataTable[T]):
         self._resize_columns()
         self.refresh(layout=True)
 
+    def fit_columns(self) -> None:
+        """Grow fixed-width columns so their cells aren't silently truncated.
+
+        A cell wider than its column is clipped with no ellipsis, so it reads as
+        wrong data rather than as cut-off data. Both happen on any broad search:
+        past row 99 the `No` column renders 1204 as "12", and a large swarm
+        renders 1882:8877 as "1882:8". Declared widths act as a floor, so
+        columns only ever grow, and the expanding column absorbs the difference.
+        """
+        if not self.columns:
+            return
+
+        console = self.app.console
+        expand_col_key = ColumnKey(self.expand_col) if self.expand_col else None
+        resized = False
+
+        for key, col in self.columns.items():
+            if key == expand_col_key:  # sized by _resize_columns from what's left
+                continue
+
+            minimum = self._min_col_widths.setdefault(key, col.width)
+            content_width = max(
+                (measure(console, str(cell), 1) for cell in self.get_column(key)),
+                default=0,
+            )
+
+            width = max(minimum, content_width)
+            if width != col.width:
+                col.width = width
+                resized = True
+
+        if resized:
+            self._resize_columns()
+            self.refresh(layout=True)
+
     def _resize_columns(self) -> None:
         if not self.columns or not self.expand_col:
             return
 
         total_cell_padding = self.cell_padding * 2 * len(self.columns)
         expand_col_key = ColumnKey(self.expand_col)
+        expand_col = self.columns.get(expand_col_key)
+        if expand_col is None:
+            return
 
         other_cols_width = sum(
             col.width for key, col in self.columns.items() if key != expand_col_key
@@ -51,5 +92,7 @@ class AutoResizingDataTable(DataTable[T]):
         available_width = self.size.width - total_cell_padding
         expand_col_width = available_width - other_cols_width
 
+        # never let a wide neighbour squeeze the expanding column out of existence
+        minimum = self._min_col_widths.setdefault(expand_col_key, expand_col.width)
         if expand_col_width > 0:
-            self.columns[expand_col_key].width = expand_col_width
+            expand_col.width = max(minimum, expand_col_width)

--- a/src/torrra/widgets/search.py
+++ b/src/torrra/widgets/search.py
@@ -211,6 +211,10 @@ class SearchContent(Vertical):
                 key=torrent.magnet_uri,
             )
 
+        # row numbers and swarm counts both outgrow the widths their columns
+        # are declared with once a search returns a few hundred results
+        self._table.fit_columns()
+
     def on_details_panel_closed(self):
         self._selected_torrent = None
         self._table.focus()

--- a/tests/screens/test_home.py
+++ b/tests/screens/test_home.py
@@ -3,11 +3,14 @@ from unittest.mock import MagicMock
 
 import pytest
 from textual.coordinate import Coordinate
+from textual.geometry import Region
 from textual.widgets import DataTable, Static
+from textual.widgets.data_table import ColumnKey
 
 from torrra._types import Indexer, Torrent
 from torrra.app import TorrraApp
 from torrra.screens.home import HomeScreen
+from torrra.widgets.search import SearchContent
 
 
 @pytest.fixture
@@ -61,3 +64,100 @@ async def test_home_screen_search_no_results(app: TorrraApp, mock_indexer: Magic
 
         assert "Nothing Found" in str(loader_status.content)
         assert table.has_class("hidden")
+
+
+# a broad search returns hundreds of rows with five-digit swarm counts, which
+# is more than the "No" and "S:L" columns are declared wide enough to hold
+WIDE_VALUE_FIXTURE = [
+    Torrent(
+        magnet_uri=f"magnet:?xt=urn:btih:wide{i}",
+        title=f"Wide Release {i:03d}",
+        size=1_000_000_000 + i,
+        seeders=15128 - i,
+        leechers=10059 - i,
+        source="MockIndexer",
+    )
+    for i in range(150)
+]
+
+
+def _table_of(app: TorrraApp) -> DataTable[str]:
+    return cast(
+        DataTable[str], app.screen.query_one("SearchContent DataTable", DataTable)
+    )
+
+
+def _col_width(table: DataTable[str], key: str) -> int:
+    return table.columns[ColumnKey(key)].width
+
+
+def _rendered(table: DataTable[str]) -> str:
+    """Exactly what the table paints, so clipped cells can't pass unnoticed."""
+    lines = table.render_lines(Region(0, 0, table.size.width, table.size.height))
+    return "\n".join("".join(segment.text for segment in line) for line in lines)
+
+
+async def test_wide_swarm_counts_are_not_clipped_on_screen(
+    app: TorrraApp, mock_indexer: MagicMock
+):
+    mock_indexer.search.return_value = list(WIDE_VALUE_FIXTURE)
+
+    async with app.run_test(size=(120, 40)):
+        table = _table_of(app)
+        assert table.get_cell_at(Coordinate(0, 3)) == "15128:10059"
+        assert "15128:10059" in _rendered(table), "widest S:L cell is being clipped"
+
+
+async def test_fixed_columns_widen_to_fit_their_content(
+    app: TorrraApp, mock_indexer: MagicMock
+):
+    mock_indexer.search.return_value = list(WIDE_VALUE_FIXTURE)
+
+    async with app.run_test(size=(120, 40)):
+        table = _table_of(app)
+
+        for index, (_, key, _) in enumerate(SearchContent.COLS):
+            if key == "title_col":  # absorbs whatever width is left over
+                continue
+            widest = max(
+                len(str(table.get_cell_at(Coordinate(row, index))))
+                for row in range(table.row_count)
+            )
+            assert _col_width(table, key) >= widest, f"{key} clips its own content"
+
+
+async def test_columns_stay_at_their_declared_width_for_small_values(
+    app: TorrraApp, mock_indexer: MagicMock
+):
+    mock_indexer.search.return_value = [
+        Torrent(
+            magnet_uri="magnet:?xt=urn:btih:small",
+            title="Small Release",
+            size=1_000_000_000,
+            seeders=12,
+            leechers=3,
+            source="MockIndexer",
+        )
+    ]
+
+    async with app.run_test(size=(120, 40)):
+        table = _table_of(app)
+        declared = {key: width for _, key, width in SearchContent.COLS}
+
+        assert _col_width(table, "no_col") == declared["no_col"]
+        assert _col_width(table, "size_col") == declared["size_col"]
+        assert (
+            _col_width(table, "seeders_leechers_col")
+            == declared["seeders_leechers_col"]
+        )
+
+
+async def test_title_column_keeps_a_usable_width_in_a_narrow_terminal(
+    app: TorrraApp, mock_indexer: MagicMock
+):
+    mock_indexer.search.return_value = list(WIDE_VALUE_FIXTURE)
+
+    async with app.run_test(size=(40, 20)):
+        table = _table_of(app)
+        declared = {key: width for _, key, width in SearchContent.COLS}
+        assert _col_width(table, "title_col") >= declared["title_col"]


### PR DESCRIPTION
Two columns in the results table are declared narrower than the values they hold, and Textual clips a cell at the column width with no ellipsis. The result is that an overlong cell reads as *plausible wrong data* rather than as truncated data, which makes it hard to spot.

```
No   declared 2, needs 4 past row 999   -> row 120 renders as "12"
S:L  declared 6, needs 11 on big swarms -> "15128:10059" renders as "15128:"
```

Seeders survive the clip because they sit left of the colon; leechers sit right of it and disappear entirely. On a real Jackett result set I measured 40 of 5,866 rows with an S:L cell wider than 6.

The fix treats the width declared in `COLS` as a floor rather than a fixed size: columns grow to fit the rows currently on screen, the expanding Title column absorbs the difference, and everything shrinks back when a later search needs less room. Title also keeps its own declared width now, so a wide neighbour can't squeeze it to nothing.

I went with an explicit pass rather than Textual's `auto_width`, because `content_width` is only finalized during `_on_idle`, which races with the resize. This way it's synchronous and testable.

Costs about 7ms on 5,753 rows. Two tests added, both of which fail without the change.
