### PR TITLE
feat: add file selection before download and in-app file manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ torrra # default indexer will be used
 
 - Search with [`Jackett`](https://github.com/Jackett/Jackett) or [`Prowlarr`](https://github.com/Prowlarr/Prowlarr)
 - Download torrents directly with pause/resume support
+- Pick which files of a torrent to download, and manage them anytime with the built-in file manager
 - Beautiful and responsive TUI built with [`Textual`](https://textual.textualize.io/)
 - Customizable themes (dark, light, and more)
 - Smart config + opt-in caching for fast searches

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ max_retries = 3                               # The maximum number of times to r
 use_cache = true                              # If true, search results will be cached to speed up subsequent searches.
 cache_ttl = 300                               # The time in seconds that search results will be cached.
 seed_ratio = 1.5                              # Target upload/download ratio. Seeding stops when reached. Omit or set None for infinite seeding.
+select_files = true                           # If true, lets you pick which files to download before a torrent starts.
 
 [indexers]
 default = "jackett"                           # The name of the default indexer to use if none is specified at runtime
@@ -72,6 +73,14 @@ Or, you can set it directly from the command line:
 
 ```bash
 torrra config set general.theme gruvbox
+```
+
+### Selecting Files Before Download
+
+`general.select_files` (default `true`) controls whether a file-selection screen is shown before a torrent starts downloading. When enabled you can pick which files of the torrent to download; disabled torrents download in full immediately.
+
+```bash
+torrra config set general.select_files false
 ```
 
 ### Indexer Selection

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Welcome to the official docs for **torrra** - A Python tool that lets you find a
 - Fetch and download magnet links directly, powered by [`Libtorrent`](https://libtorrent.org/)
 - A responsive download manager built with [`Textual`](https://textual.textualize.io/)
 - Pause and resume torrent downloads using keyboard shortcuts
+- Pick which files of a torrent to download, and re-select them anytime with the built-in file manager
 - Operates as both a `CLI` tool and a full-screen terminal `UI`
 - Toggle between dark and light themes
 - Opt-in caching for blazing fast repeated searches

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,7 +52,44 @@ torrra download "magnet:?xt=urn:btih:..."
 # or torrra download "/path/to/file.torrent"
 ```
 
-This command will immediately start the download and open the downloads interface showing the new torrent.
+This command will start the download and open the downloads interface showing the new torrent.
+
+## Selecting Files Before Downloading
+
+By default, before a torrent starts downloading, `torrra` shows a file-selection screen that lets you choose which files to include:
+
+1. The torrent is fetched (for magnet URIs, this waits for metadata to arrive from peers).
+2. A tree of every file in the torrent appears, grouped by directory, all selected by default.
+3. Toggle a file with `Space`/`Enter`, or toggle an entire directory (all of its files at once). Use **Select all** / **Select none** to bulk-change the selection.
+4. Navigate with `j`/`k` and expand/collapse directories with `←`/`→`.
+5. Press **Download** to start downloading only the selected files, or **Cancel** to abort.
+
+While metadata is being fetched, nothing is written to disk: the torrent runs in metadata-only mode with all files at priority `dont_download`, so unselected files are never created. Files are only written once you confirm a selection (or press `Escape` to download everything).
+
+Your file selection is saved with the download. If you restart `torrra`, only the files you picked are downloaded — the selection is re-applied to the torrent when it is restored, so it never falls back to downloading every file.
+
+**Known limitation:** a deselected file that shares a piece boundary with a selected file may still have a few bytes of its data downloaded. BitTorrent pieces are hashed as a whole, and libtorrent documents that *"partial pieces may still be downloaded when setting file priorities"* (see `download_priority.hpp`). Any piece containing a selected file is downloaded in full — in libtorrent 2.1 the bytes belonging to deselected files are not written to those files (they are buffered in a temporary `.parts` file), so the deselected file is not created. This is inherent to BitTorrent piece hashing and is not a full download of the unselected file.
+
+After the download reaches 100% you may briefly see a non-zero download speed (~10-20 seconds). This is not real downloading: it is libtorrent's rate estimate decaying after the final pieces arrived in flight. `torrra` hides it once the torrent is marked complete.
+
+You don't have to wait for the metadata spinner or pick files at all: press **`Escape`** at any time (even while metadata is still loading) to skip selection and download every file.
+
+The file selection screen is shown for every download entry point: search results, `torrra download <magnet_uri>`, and `torrra download <file.torrent>`.
+
+You can skip the prompt and download everything immediately by disabling it:
+
+```bash
+torrra config set general.select_files false
+```
+
+## Managing Files After Download
+
+Press **`f`** on a torrent in the downloads view to open the file manager. It lists every file in the torrent with its selection state, size, bytes downloaded, and completion percentage, and lets you change which files are included at any time — while a torrent is still downloading or after it has finished.
+
+- Move through the list with `j`/`k` and toggle a file on or off with `space`.
+- Press **Apply** to save your changes: the new selection is applied to the running torrent immediately and persisted, so it is re-applied if you restart `torrra` (see [Selecting Files Before Downloading](#selecting-files-before-downloading)).
+- Press **Close** or `esc` to exit without changing anything.
+- At least one file must remain selected; the file manager refuses to apply an empty selection.
 
 ## Command-Line Interface (CLI)
 
@@ -103,6 +140,8 @@ Once `torrra` is running (after specifying an indexer), you'll interact with it 
 | `G`           | Scroll to the bottom of the results list                                   |
 | `gg`          | Scroll to the top of the results list (press `g` twice)                    |
 | `Tab`         | Move focus to the next interactive widget (e.g., search box, results list) |
-| `p`           | Pause the currently active download                                        |
-| `r`           | Resume a previously paused download                                        |
-| `q`           | Quit `torrra` and exit the application                                     |
+| `p`           | Pause or resume the currently selected download                       |
+| `f`           | Open the file manager for the currently selected download             |
+| `d`           | Delete the currently selected download from the list                  |
+| `D`           | Delete the currently selected download and its data                   |
+| `q`           | Quit `torrra` and exit the application                                |

--- a/src/torrra/_types.py
+++ b/src/torrra/_types.py
@@ -39,6 +39,7 @@ class TorrentRecord(TypedDict):
     source: str
     is_paused: bool
     is_notified: bool
+    selected_files: list[int] | None
 
 
 @dataclass
@@ -51,6 +52,7 @@ class Torrent:
     seeders: int
     leechers: int
     source: str
+    selected_files: list[int] | None = None
 
     @classmethod
     def from_dict(cls, d: TorrentDict) -> "Torrent":
@@ -58,6 +60,26 @@ class Torrent:
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+@dataclass(frozen=True)
+class TorrentFile:
+    """A single file inside a torrent."""
+
+    index: int
+    path: str
+    size: int
+
+
+@dataclass(frozen=True)
+class TorrentFileStatus:
+    """Per-file download status inside a torrent."""
+
+    index: int
+    path: str
+    size: int
+    downloaded: int
+    priority: int
 
 
 # INDEXER TYPES

--- a/src/torrra/app.py
+++ b/src/torrra/app.py
@@ -8,6 +8,7 @@ from textual.types import CSSPathType
 
 from torrra._types import Indexer
 from torrra.core.config import get_config
+from torrra.screens.file_selection import FileSelectionResult
 from torrra.screens.home import HomeScreen
 from torrra.screens.theme_selector import ThemeSelectorScreen
 from torrra.screens.welcome import WelcomeScreen
@@ -78,6 +79,19 @@ class TorrraApp(App[None]):
 
     def action_switch_theme(self) -> None:
         self.push_screen(ThemeSelectorScreen())
+
+    @work(exclusive=True)
+    async def _run_file_selection(
+        self, magnet_uri: str, title: str
+    ) -> FileSelectionResult:
+        """Show the file-selection modal for a torrent awaiting metadata."""
+        from torrra.core.download import get_download_manager
+        from torrra.screens.file_selection import FileSelectionScreen
+
+        dm = get_download_manager()
+        return await self.push_screen_wait(
+            FileSelectionScreen(title, lambda: dm.wait_for_metadata(magnet_uri))
+        )
 
     @work(exclusive=True)
     async def _show_welcome_and_search(self) -> None:

--- a/src/torrra/app.tcss
+++ b/src/torrra/app.tcss
@@ -161,3 +161,130 @@ ThemeSelectorScreen {
     }
   }
 }
+
+/* ------------------------- */
+/* FILE SELECTION SCREEN     */
+/* ------------------------- */
+FileSelectionScreen {
+  align: center middle;
+  #file_selection_container {
+    width: 80%;
+    max-width: 90;
+    height: 80%;
+    max-height: 80%;
+    background: $surface;
+    border: tall $secondary;
+    padding: 1;
+    #file_selection_title {
+      text-align: center;
+      height: auto;
+    }
+    #file_selection_loader {
+      align: center middle;
+      height: 1fr;
+      Static {
+        content-align-horizontal: center;
+      }
+      Spinner {
+        height: auto;
+        content-align-horizontal: center;
+        color: $secondary;
+      }
+    }
+    #file_selection_header {
+      height: auto;
+      padding: 0 1;
+      color: $text-secondary;
+      text-style: bold;
+    }
+    #file_selection_tree {
+      height: 1fr;
+      margin-top: 1;
+      border: solid $secondary-muted;
+      padding: 0 1;
+      & > .tree--highlight-line {
+        background: $primary-muted;
+      }
+      &:focus {
+        border: solid $secondary;
+      }
+    }
+    #file_selection_hint {
+      height: auto;
+      margin-top: 1;
+      padding: 0 1;
+      color: $foreground-muted;
+      text-align: center;
+    }
+    #file_selection_footer {
+      height: auto;
+      margin-top: 1;
+      Button {
+        margin-right: 1;
+      }
+    }
+  }
+}
+
+/* ------------------------- */
+/* FILE MANAGER SCREEN       */
+/* ------------------------- */
+FileManagerScreen {
+  align: center middle;
+  #file_manager_container {
+    width: 80%;
+    max-width: 90;
+    height: 80%;
+    max-height: 80%;
+    background: $surface;
+    border: tall $secondary;
+    padding: 1;
+    #file_manager_title {
+      text-align: center;
+      height: auto;
+    }
+    #file_manager_loader {
+      align: center middle;
+      height: 1fr;
+      Static {
+        content-align-horizontal: center;
+      }
+      Spinner {
+        height: auto;
+        content-align-horizontal: center;
+        color: $secondary;
+      }
+    }
+    #file_manager_header {
+      height: auto;
+      padding: 0 1;
+      color: $text-secondary;
+      text-style: bold;
+    }
+    #file_manager_table {
+      height: 1fr;
+      margin-top: 1;
+      border: solid $secondary-muted;
+      & > .datatable--header {
+        text-style: bold;
+      }
+      &:focus {
+        border: solid $secondary;
+      }
+    }
+    #file_manager_hint {
+      height: auto;
+      margin-top: 1;
+      padding: 0 1;
+      color: $foreground-muted;
+      text-align: center;
+    }
+    #file_manager_footer {
+      height: auto;
+      margin-top: 1;
+      Button {
+        margin-right: 1;
+      }
+    }
+  }
+}

--- a/src/torrra/core/config.py
+++ b/src/torrra/core/config.py
@@ -136,6 +136,7 @@ class Config:
                 "max_retries": DEFAULT_MAX_RETRIES,
                 "use_cache": True,
                 "cache_ttl": DEFAULT_CACHE_TTL,
+                "select_files": True,
             }
         }
 

--- a/src/torrra/core/db.py
+++ b/src/torrra/core/db.py
@@ -29,7 +29,8 @@ def init_db() -> None:
                 size REAL,
                 source TEXT,
                 is_paused BOOLEAN DEFAULT 0,
-                is_notified BOOLEAN DEFAULT 0
+                is_notified BOOLEAN DEFAULT 0,
+                selected_files TEXT
             )
             """
         )
@@ -38,4 +39,6 @@ def init_db() -> None:
             cursor.execute(
                 "ALTER TABLE torrents ADD COLUMN is_notified BOOLEAN DEFAULT 0"
             )
+        with suppress(sqlite3.OperationalError):
+            cursor.execute("ALTER TABLE torrents ADD COLUMN selected_files TEXT")
         conn.commit()

--- a/src/torrra/core/download.py
+++ b/src/torrra/core/download.py
@@ -1,11 +1,32 @@
+import asyncio
+import time
 from functools import lru_cache
 from typing import ClassVar
 
 import libtorrent as lt
 
-from torrra._types import TorrentStatus
+from torrra._types import TorrentFile, TorrentFileStatus, TorrentStatus
 from torrra.core.config import get_config
 from torrra.utils.magnet import fix_magnet_uri
+
+METADATA_TIMEOUT = 45.0
+
+
+def build_priorities(num_files: int, selected_indices: set[int]) -> list[int]:
+    """Build per-file download priorities (0=skip, 1=download)."""
+    return [1 if i in selected_indices else 0 for i in range(num_files)]
+
+
+def selection_priorities(selected_files: list[int] | None) -> list[int] | None:
+    """Build a partial priority vector from a saved file selection.
+
+    Files beyond the vector default to 0 via `default_dont_download`, so
+    only the saved selection is downloaded.
+    """
+    if not selected_files:
+        return None
+    max_index = max(selected_files)
+    return [1 if i in selected_files else 0 for i in range(max_index + 1)]
 
 
 @lru_cache
@@ -28,7 +49,14 @@ class DownloadManager:
             set()
         )  # Track torrents whose metadata has been updated
 
-    def add_torrent(self, magnet_uri: str, is_paused: bool = False) -> None:
+    def add_torrent(
+        self,
+        magnet_uri: str,
+        is_paused: bool = False,
+        torrent_info: lt.torrent_info | None = None,
+        metadata_only: bool = False,
+        file_priorities: list[int] | None = None,
+    ) -> None:
         if magnet_uri in self.torrents:
             # Torrent already exists, update paused state if needed
             handle = self.torrents[magnet_uri]
@@ -56,11 +84,28 @@ class DownloadManager:
 
         atp = lt.parse_magnet_uri(proper_magnet_uri)
         atp.save_path = get_config().get("general.download_path")
-        if is_paused:
+        if torrent_info is not None:
+            atp.ti = torrent_info
+        if metadata_only:
+            # Run to fetch metadata but download nothing until files are picked.
+            # upload_mode + default_dont_download keep every file at priority 0,
+            # so no empty placeholder files are created while metadata is fetched.
+            atp.flags |= (
+                lt.torrent_flags.upload_mode | lt.torrent_flags.default_dont_download
+            )
+            atp.flags &= ~lt.torrent_flags.paused
+        elif is_paused:
             atp.flags |= lt.torrent_flags.paused
             atp.flags &= ~lt.torrent_flags.auto_managed
         else:
             atp.flags |= lt.torrent_flags.auto_managed
+
+        if file_priorities is not None:
+            # Restoring a selective download: apply the saved selection now.
+            # libtorrent applies these atomically once metadata arrives, and
+            # default_dont_download keeps any files beyond the vector at 0.
+            atp.file_priorities = file_priorities
+            atp.flags |= lt.torrent_flags.default_dont_download
 
         # Add the torrent to the session and start tracking
         self.torrents[magnet_uri] = self.session.add_torrent(atp)
@@ -73,6 +118,119 @@ class DownloadManager:
             else:
                 self.session.remove_torrent(handle)
             del self.torrents[magnet_uri]
+
+    def has_metadata(self, magnet_uri: str) -> bool:
+        handle = self.torrents.get(magnet_uri)
+        return bool(handle and handle.is_valid() and handle.has_metadata())
+
+    def get_files(self, magnet_uri: str) -> list[TorrentFile] | None:
+        handle = self.torrents.get(magnet_uri)
+        if not handle or not handle.is_valid() or not handle.has_metadata():
+            return None
+
+        try:
+            torrent_info = handle.torrent_file()
+        except (AttributeError, RuntimeError):
+            return None
+        if not torrent_info:
+            return None
+
+        files = torrent_info.files()
+        return [
+            TorrentFile(index=i, path=files.file_path(i), size=files.file_size(i))
+            for i in range(files.num_files())
+        ]
+
+    def get_file_details(self, magnet_uri: str) -> list[TorrentFileStatus] | None:
+        handle = self.torrents.get(magnet_uri)
+        if not handle or not handle.is_valid() or not handle.has_metadata():
+            return None
+
+        try:
+            torrent_info = handle.torrent_file()
+        except (AttributeError, RuntimeError):
+            return None
+        if not torrent_info:
+            return None
+
+        files = torrent_info.files()
+        num_files = files.num_files()
+
+        try:
+            downloaded = handle.file_progress()
+        except (AttributeError, RuntimeError):
+            downloaded = []
+        try:
+            priorities = handle.file_priorities()
+        except (AttributeError, RuntimeError):
+            priorities = []
+
+        return [
+            TorrentFileStatus(
+                index=i,
+                path=files.file_path(i),
+                size=files.file_size(i),
+                downloaded=downloaded[i] if i < len(downloaded) else 0,
+                priority=priorities[i] if i < len(priorities) else 0,
+            )
+            for i in range(num_files)
+        ]
+
+    def get_metadata(self, magnet_uri: str) -> tuple[str, int] | None:
+        handle = self.torrents.get(magnet_uri)
+        if not handle or not handle.is_valid() or not handle.has_metadata():
+            return None
+
+        try:
+            torrent_info = handle.torrent_file()
+        except (AttributeError, RuntimeError):
+            return None
+        if not torrent_info:
+            return None
+
+        return torrent_info.name(), torrent_info.total_size()
+
+    async def wait_for_metadata(
+        self, magnet_uri: str, timeout: float = METADATA_TIMEOUT
+    ) -> list[TorrentFile] | None:
+        handle = self.torrents.get(magnet_uri)
+        if not handle or not handle.is_valid():
+            return None
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if handle.has_metadata():
+                return self.get_files(magnet_uri)
+            await asyncio.sleep(0.5)
+        return None
+
+    def prioritize_files(self, magnet_uri: str, selected_indices: set[int]) -> bool:
+        handle = self.torrents.get(magnet_uri)
+        if not handle or not handle.is_valid() or not handle.has_metadata():
+            return False
+
+        try:
+            torrent_info = handle.torrent_file()
+        except (AttributeError, RuntimeError):
+            return False
+        if not torrent_info:
+            return False
+
+        num_files = torrent_info.files().num_files()
+        handle.prioritize_files(build_priorities(num_files, selected_indices))
+        return True
+
+    def resume_torrent(self, magnet_uri: str) -> bool:
+        handle = self.torrents.get(magnet_uri)
+        if not handle or not handle.is_valid():
+            return False
+
+        handle.unset_flags(
+            lt.torrent_flags.upload_mode | lt.torrent_flags.default_dont_download
+        )
+        handle.set_flags(lt.torrent_flags.auto_managed)
+        handle.resume()
+        return True
 
     def toggle_pause(self, magnet_uri: str) -> None:
         handle = self.torrents.get(magnet_uri)
@@ -105,10 +263,16 @@ class DownloadManager:
             if remaining_bytes > 0 and s.download_rate > 0:
                 eta = remaining_bytes / s.download_rate
 
+        # Once all wanted bytes are done the torrent is complete for the user.
+        # libtorrent may still pull the priority-0 portion of pieces shared
+        # with deselected files ("partial pieces may still be downloaded"),
+        # so report no download speed while finished/seeding.
+        down_speed = 0.0 if is_seeding else s.download_rate
+
         return TorrentStatus(
             state=s.state,
             progress=s.progress * 100,
-            down_speed=s.download_rate,
+            down_speed=down_speed,
             up_speed=s.upload_rate,
             seeders=s.num_seeds,
             leechers=s.num_peers,

--- a/src/torrra/core/torrent.py
+++ b/src/torrra/core/torrent.py
@@ -1,3 +1,4 @@
+import json
 import sqlite3
 from functools import lru_cache
 
@@ -17,14 +18,16 @@ class TorrentManager:
             cursor = conn.cursor()
             cursor.execute(
                 """
-                INSERT OR IGNORE INTO torrents (magnet_uri, title, size, source)
-                VALUES (?, ?, ?, ?)
+                INSERT OR IGNORE INTO torrents
+                    (magnet_uri, title, size, source, selected_files)
+                VALUES (?, ?, ?, ?, ?)
                 """,
                 (
                     torrent.magnet_uri,
                     torrent.title,
                     torrent.size,
                     torrent.source,
+                    _dumps_selection(torrent.selected_files),
                 ),
             )
             conn.commit()
@@ -62,6 +65,17 @@ class TorrentManager:
             )
             conn.commit()
 
+    def update_torrent_selected_files(
+        self, magnet_uri: str, selected_files: list[int] | None
+    ) -> None:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "UPDATE torrents SET selected_files = ? WHERE magnet_uri = ?",
+                (_dumps_selection(selected_files), magnet_uri),
+            )
+            conn.commit()
+
     def get_all_torrents(self) -> list[TorrentRecord]:
         with get_db_connection() as conn:
             conn.row_factory = sqlite3.Row
@@ -77,6 +91,20 @@ class TorrentManager:
                     source=row["source"],
                     is_paused=bool(row["is_paused"]),
                     is_notified=bool(row["is_notified"]),
+                    selected_files=_loads_selection(row["selected_files"]),
                 )
                 for row in rows
             ]
+
+
+def _dumps_selection(selected_files: list[int] | None) -> str | None:
+    return json.dumps(selected_files) if selected_files is not None else None
+
+
+def _loads_selection(raw: str | None) -> list[int] | None:
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError):
+        return None

--- a/src/torrra/screens/file_manager.py
+++ b/src/torrra/screens/file_manager.py
@@ -1,0 +1,251 @@
+import inspect
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, ClassVar
+
+from rich.markup import escape
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+from textual.worker import Worker
+from typing_extensions import override
+
+from torrra._types import TorrentFileStatus
+from torrra.core.download import METADATA_TIMEOUT
+from torrra.utils.helpers import human_readable_size
+from torrra.widgets.data_table import AutoResizingDataTable
+from torrra.widgets.spinner import Spinner
+
+FileManagerResult = list[int] | None
+
+
+class FileManagerScreen(ModalScreen[FileManagerResult]):
+    """Modal showing per-file status that lets the user re/deselect files."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "close", "Close"),
+        Binding("space", "toggle_file", "Toggle selection"),
+    ]
+
+    def __init__(
+        self,
+        title: str,
+        load_status: Callable[[], Awaitable[list[TorrentFileStatus] | None]],
+        *args: Any,
+        metadata_timeout: float = METADATA_TIMEOUT,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._torrent_title: str = title
+        self._load_status = load_status
+        self._metadata_timeout: float = metadata_timeout
+
+        self._statuses: list[TorrentFileStatus] = []
+        self._selected: set[int] = set()
+        self._total_size: int = 0
+        self._table_ready: bool = False
+        self._waiting_for_metadata: bool = False
+        self._metadata_deadline: float = 0.0
+        self._load_worker: Worker[None]
+
+        # ui refs (cached later)
+        self._loader: Vertical
+        self._header: Static
+        self._table: AutoResizingDataTable[str]
+        self._footer: Horizontal
+
+    @override
+    def compose(self) -> ComposeResult:
+        with Vertical(id="file_manager_container"):
+            yield Static(f"[b]{self._torrent_title}[/b]", id="file_manager_title")
+            with Vertical(id="file_manager_loader"):
+                yield Static("Loading file status...")
+                yield Spinner(name="dots")
+            yield Static("", id="file_manager_header", classes="hidden")
+            yield AutoResizingDataTable(id="file_manager_table", classes="hidden")
+            yield Static(
+                "[b]space[/b] toggle  ·  [b]j/k[/b] move  ·  [b]esc[/b] close",
+                id="file_manager_hint",
+            )
+            with Horizontal(id="file_manager_footer", classes="hidden"):
+                yield Button("Apply", variant="success", id="file_manager_apply")
+                yield Button("Close", variant="error", id="file_manager_close")
+
+    def on_mount(self) -> None:
+        self._loader = self.query_one("#file_manager_loader", Vertical)
+        self._header = self.query_one("#file_manager_header", Static)
+        self._table = self.query_one("#file_manager_table", AutoResizingDataTable)
+        self._footer = self.query_one("#file_manager_footer", Horizontal)
+        self._table.expand_col = "name"
+        for label, key, width in self.COLUMNS:
+            self._table.add_column(label, width=width, key=key)
+
+        self.set_interval(1.0, self._refresh)
+        self._load_worker = self._load_data()
+
+    COLUMNS: ClassVar[list[tuple[str, str, int]]] = [
+        ("Sel", "sel", 3),
+        ("Name", "name", 25),
+        ("Size", "size", 8),
+        ("Downloaded", "downloaded", 10),
+        ("Done", "done", 5),
+    ]
+
+    @work(exclusive=True)
+    async def _load_data(self) -> None:
+        try:
+            statuses = await self._fetch()
+        except Exception as exc:  # noqa: BLE001 - surface any failure instead of hanging
+            self._fail_load(f"Could not load file status: {exc}")
+            return
+        if statuses is None:
+            self._waiting_for_metadata = True
+            self._metadata_deadline = time.monotonic() + self._metadata_timeout
+            return
+
+        self._apply_statuses(statuses)
+
+    async def _fetch(self) -> list[TorrentFileStatus] | None:
+        result = self._load_status()
+        if inspect.isawaitable(result):
+            result = await result
+        return result
+
+    def _apply_statuses(self, statuses: list[TorrentFileStatus]) -> None:
+        self._statuses = statuses
+        try:
+            self._populate()
+        except Exception as exc:  # noqa: BLE001 - surface any render failure
+            self.log.error("file manager: failed to render file list: %r", exc)
+            self._fail_load(f"Could not load file status: {exc}")
+
+    def _fail_load(self, message: str) -> None:
+        if not self.is_mounted:
+            return
+        self.log.error("file manager: load failed: %s", message)
+        self.notify(message, title="Load Error", severity="error")
+        self.dismiss(None)
+
+    def _populate(self) -> None:
+        self._table.clear()
+        self._total_size = sum(self._file_size(s) for s in self._statuses)
+        self._selected = {s.index for s in self._statuses if s.priority > 0}
+
+        for status in self._statuses:
+            self._table.add_row(
+                self._marker(status.index),
+                escape(str(status.path or "")),
+                human_readable_size(self._file_size(status), short=True),
+                human_readable_size(self._file_downloaded(status), short=True),
+                self._done_text(status),
+                key=str(status.index),
+            )
+
+        self._table_ready = True
+        self._waiting_for_metadata = False
+        self._loader.add_class("hidden")
+        self._header.remove_class("hidden")
+        self._table.remove_class("hidden")
+        self._footer.remove_class("hidden")
+        self._update_header()
+        self._table.focus()
+
+    def _update_header(self) -> None:
+        self._header.update(
+            f"{len(self._statuses)} files - "
+            f"{human_readable_size(self._total_size)}"
+            f"  ·  selected {human_readable_size(self._selected_size())} "
+            f"({len(self._selected)} files)"
+        )
+
+    def _selected_size(self) -> int:
+        return sum(
+            self._file_size(s) for s in self._statuses if s.index in self._selected
+        )
+
+    async def _refresh(self) -> None:
+        if not self._table_ready:
+            await self._try_first_load()
+            return
+        try:
+            statuses = await self._fetch()
+        except Exception as exc:  # noqa: BLE001 - keep the screen usable on refresh errors
+            self.log.error("file manager: refresh failed: %r", exc)
+            return
+        if not statuses or not self._table_ready:
+            return
+
+        self._statuses = statuses
+        for status in statuses:
+            try:
+                key = str(status.index)
+                self._table.update_cell(
+                    key,
+                    "downloaded",
+                    human_readable_size(self._file_downloaded(status), short=True),
+                )
+                self._table.update_cell(key, "done", self._done_text(status))
+            except Exception as exc:  # noqa: BLE001 - skip cells that can't be updated
+                self.log.debug("file manager: cell update failed: %r", exc)
+                continue
+
+    async def _try_first_load(self) -> None:
+        if not self._waiting_for_metadata:
+            return
+        try:
+            statuses = await self._fetch()
+        except Exception as exc:  # noqa: BLE001 - surface any failure instead of hanging
+            self._fail_load(f"Could not load file status: {exc}")
+            return
+        if statuses is not None:
+            self._apply_statuses(statuses)
+        elif time.monotonic() >= self._metadata_deadline:
+            self._fail_load(
+                "Could not load file status: timed out waiting for metadata"
+            )
+
+    def _marker(self, index: int) -> str:
+        return "\\[x]" if index in self._selected else "\\[ ]"
+
+    def _file_size(self, status: TorrentFileStatus) -> int:
+        return max(0, int(status.size or 0))
+
+    def _file_downloaded(self, status: TorrentFileStatus) -> int:
+        return max(0, int(status.downloaded or 0))
+
+    def _done_text(self, status: TorrentFileStatus) -> str:
+        size = self._file_size(status)
+        if size <= 0:
+            return "100%"
+        return f"{min(100, int(self._file_downloaded(status) / size * 100))}%"
+
+    def action_toggle_file(self) -> None:
+        row = self._table.cursor_row
+        if row is None:
+            return
+        index = int(row)
+        if index in self._selected:
+            self._selected.discard(index)
+        else:
+            self._selected.add(index)
+        self._table.update_cell(str(index), "sel", self._marker(index))
+        self._update_header()
+
+    def action_close(self) -> None:
+        self.dismiss(None)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "file_manager_apply":
+            if not self._selected:
+                self.notify(
+                    "Select at least one file to download",
+                    title="No Files Selected",
+                    severity="warning",
+                )
+                return
+            self.dismiss(sorted(self._selected))
+        elif event.button.id == "file_manager_close":
+            self.dismiss(None)

--- a/src/torrra/screens/file_selection.py
+++ b/src/torrra/screens/file_selection.py
@@ -1,0 +1,141 @@
+from collections.abc import Awaitable, Callable
+from typing import Any, ClassVar, Literal
+
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+from textual.worker import Worker
+from typing_extensions import override
+
+from torrra._types import TorrentFile
+from torrra.utils.helpers import human_readable_size
+from torrra.widgets.file_tree import FileTree
+from torrra.widgets.spinner import Spinner
+
+DOWNLOAD_ALL: Literal["download_all"] = "download_all"
+
+FileSelectionResult = list[int] | Literal["download_all"] | None
+
+
+class FileSelectionScreen(ModalScreen[FileSelectionResult]):
+    """Modal that lets the user pick which torrent files to download."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "download_all", "Download all"),
+    ]
+
+    def __init__(
+        self,
+        title: str,
+        load_files: Callable[[], Awaitable[list[TorrentFile] | None]],
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._torrent_title: str = title
+        self._load_files = load_files
+
+        self._files: list[TorrentFile] = []
+        self._file_sizes: dict[int, int] = {}
+        self._total_size: int = 0
+        self._load_worker: Worker[None]
+
+        # ui refs (cached later)
+        self._loader: Vertical
+        self._header: Static
+        self._file_tree: FileTree
+        self._footer: Horizontal
+
+    @override
+    def compose(self) -> ComposeResult:
+        with Vertical(id="file_selection_container"):
+            yield Static(f"[b]{self._torrent_title}[/b]", id="file_selection_title")
+            with Vertical(id="file_selection_loader"):
+                yield Static("Fetching torrent metadata...")
+                yield Spinner(name="dots")
+            yield Static("", id="file_selection_header", classes="hidden")
+            yield FileTree(id="file_selection_tree", classes="hidden")
+            yield Static(
+                "[b]esc[/b] download all files  ·  [b]space[/b] toggle  ·  "
+                "[b]j/k[/b] move  ·  [b]left/right[/b] expand",
+                id="file_selection_hint",
+            )
+            with Horizontal(id="file_selection_footer", classes="hidden"):
+                yield Button("Select all", id="select_all_button")
+                yield Button("Select none", id="select_none_button")
+                yield Button("Cancel", variant="error", id="cancel_button")
+                yield Button("Download", variant="success", id="download_button")
+
+    def on_mount(self) -> None:
+        self._loader = self.query_one("#file_selection_loader", Vertical)
+        self._header = self.query_one("#file_selection_header", Static)
+        self._file_tree = self.query_one("#file_selection_tree", FileTree)
+        self._footer = self.query_one("#file_selection_footer", Horizontal)
+
+        self._load_worker = self._load_metadata()
+
+    @work(exclusive=True)
+    async def _load_metadata(self) -> None:
+        files = await self._load_files()
+        if files is None:
+            self.notify(
+                "Failed to fetch torrent metadata",
+                title="Metadata Error",
+                severity="error",
+            )
+            self.dismiss(None)
+            return
+
+        self._files = files
+        self._show_file_list()
+
+    def _show_file_list(self) -> None:
+        self._file_sizes = {f.index: f.size for f in self._files}
+        self._total_size = sum(f.size for f in self._files)
+
+        self._loader.add_class("hidden")
+        self._header.remove_class("hidden")
+        self._file_tree.remove_class("hidden")
+        self._footer.remove_class("hidden")
+
+        self._file_tree.populate(self._files, selected={f.index for f in self._files})
+        self._update_selection_header()
+        self._file_tree.focus()
+
+    def _update_selection_header(self) -> None:
+        selected = self._file_tree.selected_indices()
+        selected_size = sum(self._file_sizes.get(i, 0) for i in selected)
+        self._header.update(
+            f"{len(self._files)} files - {human_readable_size(self._total_size)}"
+            f"  ·  selected {human_readable_size(selected_size)} ({len(selected)} files)"
+        )
+
+    def on_file_tree_selection_changed(self, event: FileTree.SelectionChanged) -> None:
+        self._update_selection_header()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        button_id = event.button.id
+        if button_id == "select_all_button":
+            self._file_tree.select_all()
+        elif button_id == "select_none_button":
+            self._file_tree.select_none()
+        elif button_id == "cancel_button":
+            self.dismiss(None)
+        elif button_id == "download_button":
+            selected = self._file_tree.selected_indices()
+            if not selected:
+                self.notify(
+                    "Select at least one file to download",
+                    title="No Files Selected",
+                    severity="warning",
+                )
+                return
+            self.dismiss(selected)
+
+    def action_download_all(self) -> None:
+        if not self._load_worker.is_finished:
+            self._load_worker.cancel()
+        self.dismiss(DOWNLOAD_ALL)

--- a/src/torrra/screens/home.py
+++ b/src/torrra/screens/home.py
@@ -5,7 +5,7 @@ from textual.widgets import ContentSwitcher
 from typing_extensions import override
 
 from torrra._types import Indexer, TorrentStatus
-from torrra.core.download import get_download_manager
+from torrra.core.download import get_download_manager, selection_priorities
 from torrra.core.torrent import get_torrent_manager
 from torrra.widgets.downloads import DownloadsContent
 from torrra.widgets.search import SearchContent
@@ -64,6 +64,7 @@ class HomeScreen(Screen[None]):
             dm.add_torrent(
                 torrent["magnet_uri"],
                 is_paused=torrent["is_paused"],
+                file_priorities=selection_priorities(torrent["selected_files"]),
             )
 
         if self.show_downloads and not self.direct_download:

--- a/src/torrra/utils/direct_download.py
+++ b/src/torrra/utils/direct_download.py
@@ -4,9 +4,8 @@ from typing import TYPE_CHECKING
 import libtorrent as lt
 from textual.widgets import ContentSwitcher
 
-from torrra._types import Torrent
-from torrra.core.download import get_download_manager
 from torrra.core.torrent import get_torrent_manager
+from torrra.utils.download_flow import start_download
 from torrra.utils.magnet import resolve_magnet_uri
 from torrra.widgets.sidebar import Sidebar
 
@@ -15,7 +14,7 @@ if TYPE_CHECKING:
 
 
 async def handle_direct_download(home_screen: "HomeScreen", input_path: str) -> None:
-    dm, tm = get_download_manager(), get_torrent_manager()
+    tm = get_torrent_manager()
 
     # Check if it's a local torrent file
     if os.path.isfile(input_path) and input_path.endswith(".torrent"):
@@ -24,27 +23,18 @@ async def handle_direct_download(home_screen: "HomeScreen", input_path: str) -> 
             info = lt.torrent_info(input_path)
             magnet_uri = lt.make_magnet_uri(info)
 
-            # Add to download manager
-            dm.add_torrent(magnet_uri, is_paused=False)
-
-            # Create torrent record with actual metadata from the file
-            torrent_record = Torrent(
+            record = await start_download(
+                home_screen.app,
                 magnet_uri=magnet_uri,
                 title=info.name(),
                 size=info.total_size(),
                 source="Direct Download",
-                seeders=0,
-                leechers=0,
+                torrent_info=info,
             )
-            tm.add_torrent(torrent_record)
-
-            # Switch to downloads content and select the new torrent
-            home_screen.query_one(
-                "#content_switcher", ContentSwitcher
-            ).current = "downloads_content"
-            home_screen.query_one("#sidebar", Sidebar).select_node_by_group_id(
-                "downloads_content"
-            )
+            if record is None:
+                return
+            tm.add_torrent(record)
+            _switch_to_downloads(home_screen)
         except (RuntimeError, OSError, ValueError) as e:
             home_screen.app.notify(
                 f"Error processing torrent file: {e!s}", severity="error"
@@ -52,31 +42,26 @@ async def handle_direct_download(home_screen: "HomeScreen", input_path: str) -> 
     else:
         # It's a magnet URI or URL, resolve it
         if magnet_uri := await resolve_magnet_uri(input_path):
-            # Add to download manager
-            dm.add_torrent(magnet_uri, is_paused=False)
-
-            # Create a basic torrent record to add to the database
-            # For direct downloads, we'll use the magnet URI as the title initially
-            # The actual title will be updated when the torrent metadata is available
-            tm.add_torrent(
-                Torrent(
-                    magnet_uri=magnet_uri,
-                    title=magnet_uri.split("&")[0]
-                    if magnet_uri.startswith("magnet:")
-                    else input_path,
-                    size=0,  # Size will be updated when metadata is available
-                    source="Direct Download",
-                    seeders=0,
-                    leechers=0,
-                )
+            record = await start_download(
+                home_screen.app,
+                magnet_uri=magnet_uri,
+                title=magnet_uri.split("&")[0]
+                if magnet_uri.startswith("magnet:")
+                else input_path,
+                source="Direct Download",
             )
-
-            # Switch to downloads content and select the new torrent
-            home_screen.query_one(
-                "#content_switcher", ContentSwitcher
-            ).current = "downloads_content"
-            home_screen.query_one("#sidebar", Sidebar).select_node_by_group_id(
-                "downloads_content"
-            )
+            if record is None:
+                return
+            tm.add_torrent(record)
+            _switch_to_downloads(home_screen)
         else:
             home_screen.app.notify("Failed to resolve magnet URI", severity="error")
+
+
+def _switch_to_downloads(home_screen: "HomeScreen") -> None:
+    home_screen.query_one(
+        "#content_switcher", ContentSwitcher
+    ).current = "downloads_content"
+    home_screen.query_one("#sidebar", Sidebar).select_node_by_group_id(
+        "downloads_content"
+    )

--- a/src/torrra/utils/download_flow.py
+++ b/src/torrra/utils/download_flow.py
@@ -1,0 +1,86 @@
+from typing import TYPE_CHECKING
+
+import libtorrent as lt
+
+from torrra._types import Torrent
+from torrra.core.config import get_config
+from torrra.core.download import get_download_manager
+from torrra.screens.file_selection import DOWNLOAD_ALL
+
+if TYPE_CHECKING:
+    from torrra.app import TorrraApp
+
+
+async def start_download(
+    app: "TorrraApp",
+    *,
+    magnet_uri: str,
+    title: str,
+    source: str,
+    size: float = 0,
+    torrent_info: lt.torrent_info | None = None,
+) -> Torrent | None:
+    """Start a torrent download, optionally letting the user pick files first.
+
+    When `general.select_files` is enabled the torrent is added in upload mode
+    so it runs only long enough to fetch metadata without downloading anything,
+    the user picks which files to download, and only the selected files are
+    prioritized before resuming.
+
+    Returns a `Torrent` record to store in the database, or `None` if the
+    user cancelled or metadata could not be fetched.
+    """
+    dm = get_download_manager()
+
+    if not get_config().get("general.select_files", True):
+        dm.add_torrent(magnet_uri, is_paused=False, torrent_info=torrent_info)
+        return _build_record(magnet_uri, title, size, source)
+
+    dm.add_torrent(magnet_uri, metadata_only=True, torrent_info=torrent_info)
+
+    worker = app._run_file_selection(magnet_uri, title)
+    selected = await worker.wait()
+    if selected is None:
+        dm.remove_torrent(magnet_uri)
+        return None
+
+    if selected == DOWNLOAD_ALL:
+        # Download everything: restore file priorities to 1 when metadata is
+        # already available (otherwise default_dont_download is lifted by
+        # resume_torrent before metadata arrives, so files default to 1).
+        if files := dm.get_files(magnet_uri):
+            dm.prioritize_files(magnet_uri, {f.index for f in files})
+        dm.resume_torrent(magnet_uri)
+    else:
+        if not dm.prioritize_files(magnet_uri, set(selected)):
+            # Metadata vanished mid-selection; don't resume into a
+            # download-everything state, drop the torrent instead.
+            dm.remove_torrent(magnet_uri)
+            app.notify(
+                "Could not apply file selection",
+                title="Download Failed",
+                severity="error",
+            )
+            return None
+        dm.resume_torrent(magnet_uri)
+
+    # Prefer metadata from libtorrent when available (authoritative title/size)
+    record_title, record_size = title, size
+    if metadata := dm.get_metadata(magnet_uri):
+        record_title, record_size = metadata
+
+    record = _build_record(magnet_uri, record_title, record_size, source)
+    if selected is not None and selected != DOWNLOAD_ALL:
+        record.selected_files = sorted(selected)
+    return record
+
+
+def _build_record(magnet_uri: str, title: str, size: float, source: str) -> Torrent:
+    return Torrent(
+        magnet_uri=magnet_uri,
+        title=title,
+        size=size,
+        seeders=0,
+        leechers=0,
+        source=source,
+    )

--- a/src/torrra/widgets/downloads.py
+++ b/src/torrra/widgets/downloads.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, cast
 
+from textual import work
 from textual.app import ComposeResult
 from textual.containers import Vertical
 from typing_extensions import override
@@ -25,6 +26,7 @@ class DownloadsContent(Vertical):
     BINDINGS: ClassVar[list[tuple[str, str]]] = [
         ("d", "delete_torrent"),
         ("D", "delete_torrent_with_data"),
+        ("f", "show_file_manager"),
     ]
 
     def __init__(self) -> None:
@@ -59,8 +61,9 @@ class DownloadsContent(Vertical):
         self._table.clear()
         self._table.border_title = f"all ({len(self._torrents)})"
 
+        # Torrents are already added (with their saved file selection) by
+        # HomeScreen.on_mount, so this view only renders the table.
         for idx, torrent in enumerate(self._torrents):
-            self._dm.add_torrent(torrent["magnet_uri"], is_paused=torrent["is_paused"])
             self._table.add_row(
                 str(idx + 1),
                 torrent["title"],
@@ -107,6 +110,48 @@ class DownloadsContent(Vertical):
 
     def action_delete_torrent_with_data(self) -> None:
         self._remove_selected_torrent(delete_files=True)
+
+    def action_show_file_manager(self) -> None:
+        if not self._selected_torrent:
+            self.notify(
+                "Select a torrent first",
+                title="No Torrent Selected",
+                severity="warning",
+            )
+            return
+        self._file_manager_worker = self._open_file_manager()
+
+    @work(exclusive=True)
+    async def _open_file_manager(self) -> None:
+        from torrra.screens.file_manager import FileManagerScreen
+
+        magnet_uri = self._selected_torrent["magnet_uri"]
+        title = self._selected_torrent["title"]
+        screen = FileManagerScreen(title, lambda: self._dm.get_file_details(magnet_uri))
+
+        result = await self.app.push_screen_wait(screen)
+        if result is None:
+            return
+
+        if not self._dm.prioritize_files(magnet_uri, set(result)):
+            self.notify(
+                "Could not apply file selection",
+                title="Apply Failed",
+                severity="error",
+            )
+            return
+
+        self._tm.update_torrent_selected_files(magnet_uri, result)
+        for torrent in self._torrents:
+            if torrent["magnet_uri"] == magnet_uri:
+                torrent["selected_files"] = result
+                break
+
+        short_title = (title[:50] + "...") if len(title) > 40 else title
+        self.notify(
+            f"Updated files for [b]{short_title}[/b]",
+            title="File Selection Applied",
+        )
 
     def _remove_selected_torrent(self, delete_files: bool = False) -> None:
         if not self._selected_torrent:
@@ -254,7 +299,7 @@ class DownloadsContent(Vertical):
 [b]Size:[/b] {size} - [b]Status:[/b] {state_text} - [b]Source:[/b] {current_torrent["source"]}
 [b]S/L:[/b] {status["seeders"]}/{status["leechers"]} - [b]Up:[/b] {up_speed} - [b]Down:[/b] {down_speed} - [b]ETA:[/b] {eta_text}
 
-[dim]Press 'p' to pause/resume, 'd' to delete, 'D' to delete w/ data, or 'esc' to close.[/dim]
+[dim]Press 'p' to pause/resume, 'f' to manage files, 'd' to delete, 'D' to delete w/ data, or 'esc' to close.[/dim]
 """
         # update details panel internal widgets
         self._details_panel.update_content(

--- a/src/torrra/widgets/file_tree.py
+++ b/src/torrra/widgets/file_tree.py
@@ -1,0 +1,184 @@
+from typing import Any, ClassVar
+
+from rich.markup import escape
+from textual.binding import Binding, BindingType
+from textual.message import Message
+from textual.widgets import Tree
+from textual.widgets.tree import TreeNode
+from typing_extensions import override
+
+from torrra._types import TorrentFile
+from torrra.utils.helpers import human_readable_size
+
+
+class FileTree(Tree[Any]):
+    """A tree of torrent files with checkbox-style selection.
+
+    File nodes carry `{"index": int}` data; directory nodes carry
+    `{"indices": frozenset[int]}` (all descendant file indices) so a
+    directory can be toggled in bulk. Directories show `[x]` when all
+    descendants are selected, `[-]` for a partial selection, and `[ ]`
+    when none are selected.
+    """
+
+    class SelectionChanged(Message):
+        """Posted whenever the set of selected files changes."""
+
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("j", "cursor_down", show=False),
+        Binding("k", "cursor_up", show=False),
+        Binding("space", "toggle_check", "Toggle selection"),
+        Binding("enter", "toggle_check", "Toggle selection"),
+        Binding("left", "collapse_node", show=False),
+        Binding("right", "expand_node", show=False),
+    ]
+
+    def __init__(self, label: str = "Files", **kwargs: Any) -> None:
+        super().__init__(label, **kwargs)
+        self.show_root: bool = False
+        self.guide_depth: int = 3
+
+        self._selected: set[int] = set()
+        self._file_nodes: dict[int, TreeNode[Any]] = {}
+        self._file_labels: dict[int, str] = {}
+        self._file_dirs: dict[int, list[TreeNode[Any]]] = {}
+        self._dir_nodes: dict[tuple[str, ...], TreeNode[Any]] = {}
+        self._dir_labels: dict[tuple[str, ...], str] = {}
+        self._dir_key: dict[TreeNode[Any], tuple[str, ...]] = {}
+
+    def populate(self, files: list[TorrentFile], selected: set[int]) -> None:
+        """Rebuild the tree from a flat list of files."""
+        self.clear()
+        self._selected = set(selected)
+        self._file_nodes.clear()
+        self._file_labels.clear()
+        self._file_dirs.clear()
+        self._dir_nodes.clear()
+        self._dir_labels.clear()
+        self._dir_key.clear()
+
+        for file in files:
+            parts = file.path.split("/")
+            node = self.root
+            ancestors: list[TreeNode[Any]] = []
+            for i, part in enumerate(parts[:-1]):
+                key = tuple(parts[: i + 1])
+                child = self._dir_nodes.get(key)
+                if child is None:
+                    child = node.add(part + "/", allow_expand=True)
+                    child.data = {"indices": set()}
+                    self._dir_nodes[key] = child
+                    self._dir_labels[key] = part + "/"
+                    self._dir_key[child] = key
+                node = child
+                ancestors.append(node)
+
+            name = parts[-1]
+            label = f"{name} ({human_readable_size(file.size)})"
+            leaf = node.add(
+                self._format_label(file.index, label),
+                data={"index": file.index},
+                allow_expand=False,
+            )
+            self._file_nodes[file.index] = leaf
+            self._file_labels[file.index] = label
+            self._file_dirs[file.index] = list(ancestors)
+
+            for ancestor in ancestors:
+                ancestor.data["indices"].add(file.index)
+
+        for node in self._dir_nodes.values():
+            node.set_label(self._format_dir_label(node))
+            node.expand()
+
+        if self.root.children:
+            self.select_node(self.root.children[0])
+
+        self.refresh()
+
+    def toggle_cursor(self) -> None:
+        """Toggle selection of the node under the cursor."""
+        node = self.cursor_node
+        if node is None or node.data is None:
+            return
+
+        if "index" in node.data:
+            index = node.data["index"]
+            if index in self._selected:
+                self._selected.discard(index)
+            else:
+                self._selected.add(index)
+            node.set_label(self._format_label(index, self._file_labels[index]))
+            self._update_dir_labels(self._file_dirs.get(index, []))
+        elif "indices" in node.data:
+            indices = node.data["indices"]
+            if indices and indices <= self._selected:
+                self._selected.difference_update(indices)
+            else:
+                self._selected.update(indices)
+            self._update_labels(indices)
+            self._update_dir_labels([node] + self._dir_ancestors(node))
+
+        self.refresh()
+        self.post_message(self.SelectionChanged())
+
+    def select_all(self) -> None:
+        self._selected = set(self._file_nodes)
+        self._update_labels(self._selected)
+        self._update_dir_labels(list(self._dir_nodes.values()))
+        self.post_message(self.SelectionChanged())
+
+    def select_none(self) -> None:
+        self._selected.clear()
+        self._update_labels(self._file_nodes.keys())
+        self._update_dir_labels(list(self._dir_nodes.values()))
+        self.post_message(self.SelectionChanged())
+
+    def selected_indices(self) -> list[int]:
+        return sorted(self._selected)
+
+    def _update_labels(self, indices: Any) -> None:
+        for index in indices:
+            node = self._file_nodes.get(index)
+            if node is not None:
+                node.set_label(self._format_label(index, self._file_labels[index]))
+
+    def _update_dir_labels(self, nodes: list[TreeNode[Any]]) -> None:
+        for node in nodes:
+            if node is not None and node in self._dir_key:
+                node.set_label(self._format_dir_label(node))
+
+    def _dir_ancestors(self, node: TreeNode[Any]) -> list[TreeNode[Any]]:
+        key = self._dir_key.get(node)
+        if not key:
+            return []
+        return [self._dir_nodes[key[:i]] for i in range(1, len(key))]
+
+    def _format_label(self, index: int, label: str) -> str:
+        marker = "\\[x]" if index in self._selected else "\\[ ]"
+        return f"{marker} {escape(label)}"
+
+    def _format_dir_label(self, node: TreeNode[Any]) -> str:
+        indices = node.data.get("indices", set())
+        if not indices or not indices & self._selected:
+            marker = "\\[ ]"
+        elif indices <= self._selected:
+            marker = "\\[x]"
+        else:
+            marker = "\\[-]"
+        base = self._dir_labels.get(self._dir_key[node], "")
+        return f"{marker} {escape(base)}"
+
+    def action_expand_node(self) -> None:
+        node = self.cursor_node
+        if node is not None and not node.is_expanded:
+            node.expand()
+
+    def action_collapse_node(self) -> None:
+        node = self.cursor_node
+        if node is not None and node.is_expanded:
+            node.collapse()
+
+    @override
+    def action_toggle_check(self) -> None:
+        self.toggle_cursor()

--- a/src/torrra/widgets/search.py
+++ b/src/torrra/widgets/search.py
@@ -135,15 +135,27 @@ class SearchContent(Vertical):
                         title="Torrent Opened",
                     )
             else:  # continue with libtorrent
+                from torrra.utils.download_flow import start_download
+
+                record = await start_download(
+                    self.app,
+                    magnet_uri=resolved_magnet_uri,
+                    title=self._selected_torrent.title,
+                    size=self._selected_torrent.size,
+                    source=self._selected_torrent.source,
+                )
+                if record is None:
+                    return
+
                 tm = get_torrent_manager()
-                tm.add_torrent(self._selected_torrent)
-                title = self._selected_torrent.title
+                tm.add_torrent(record)
+                title = record.title
                 short_title = (title[:30] + "...") if len(title) > 30 else title
                 self.notify(
                     f"Started downloading [b]{short_title}[/b]",
                     title="Download Started",
                 )
-                self.post_message(self.DownloadRequested(self._selected_torrent))
+                self.post_message(self.DownloadRequested(record))
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         query = event.value

--- a/tests/screens/test_file_manager.py
+++ b/tests/screens/test_file_manager.py
@@ -1,0 +1,243 @@
+from textual import work
+from textual.app import App
+
+from torrra._types import TorrentFileStatus
+from torrra.screens.file_manager import FileManagerScreen
+from torrra.widgets.data_table import AutoResizingDataTable
+
+STATUS = [
+    TorrentFileStatus(index=0, path="readme.txt", size=10, downloaded=10, priority=1),
+    TorrentFileStatus(index=1, path="video.mp4", size=20, downloaded=5, priority=0),
+    TorrentFileStatus(index=2, path="subs/en.srt", size=5, downloaded=0, priority=1),
+]
+
+
+class _ScreenApp(App[None]):
+    @work(exclusive=True)
+    async def _open_and_wait(self, screen: FileManagerScreen) -> None:
+        return await self.push_screen_wait(screen)
+
+
+async def _load_status() -> list[TorrentFileStatus] | None:
+    return STATUS
+
+
+async def _open(app: App, pilot) -> FileManagerScreen:
+    screen = FileManagerScreen("Test Torrent", _load_status)
+    app._open_and_wait(screen)
+    await pilot.pause()
+    await pilot.pause()
+    return screen
+
+
+async def test_file_manager_lists_file_status():
+    app = _ScreenApp()
+
+    async with app.run_test() as pilot:
+        screen = await _open(app, pilot)
+
+        table = screen.query_one("#file_manager_table", AutoResizingDataTable)
+        assert table.row_count == 3
+        assert table.get_cell("0", "sel") == "\\[x]"
+        assert table.get_cell("1", "sel") == "\\[ ]"
+        assert table.get_cell("0", "done") == "100%"
+        assert table.get_cell("1", "done") == "25%"
+        assert table.get_cell("2", "done") == "0%"
+        assert table.get_cell("1", "downloaded") == "5B"
+        assert table.get_cell("2", "name") == "subs/en.srt"
+        assert "selected 15.00 B (2 files)" in str(
+            screen.query_one("#file_manager_header").content
+        )
+
+
+async def test_file_manager_toggle_on_and_apply_returns_selection():
+    app = _ScreenApp()
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(FileManagerScreen("Test Torrent", _load_status))
+        await pilot.pause()
+        await pilot.pause()
+
+        table = app.screen.query_one("#file_manager_table", AutoResizingDataTable)
+        table.move_cursor(row=1)  # video.mp4 (currently deselected)
+        await pilot.press("space")
+
+        assert table.get_cell("1", "sel") == "\\[x]"
+        assert "selected 35.00 B (3 files)" in str(
+            app.screen.query_one("#file_manager_header").content
+        )
+
+        await pilot.click("#file_manager_apply")
+
+        assert await worker.wait() == [0, 1, 2]
+
+
+async def test_file_manager_toggle_off_and_apply_returns_selection():
+    app = _ScreenApp()
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(FileManagerScreen("Test Torrent", _load_status))
+        await pilot.pause()
+        await pilot.pause()
+
+        table = app.screen.query_one("#file_manager_table", AutoResizingDataTable)
+        table.move_cursor(row=0)  # readme.txt (currently selected)
+        await pilot.press("space")
+
+        assert table.get_cell("0", "sel") == "\\[ ]"
+
+        await pilot.click("#file_manager_apply")
+
+        assert await worker.wait() == [2]
+
+
+async def test_file_manager_escape_returns_none():
+    app = _ScreenApp()
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(FileManagerScreen("Test Torrent", _load_status))
+        await pilot.pause()
+        await pilot.pause()
+
+        await pilot.press("escape")
+
+        assert await worker.wait() is None
+
+
+async def test_file_manager_close_button_returns_none():
+    app = _ScreenApp()
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(FileManagerScreen("Test Torrent", _load_status))
+        await pilot.pause()
+        await pilot.pause()
+
+        await pilot.click("#file_manager_close")
+
+        assert await worker.wait() is None
+
+
+async def test_file_manager_empty_selection_blocked():
+    async def _empty() -> list[TorrentFileStatus] | None:
+        return [
+            TorrentFileStatus(index=0, path="a.bin", size=10, downloaded=0, priority=0),
+            TorrentFileStatus(index=1, path="b.bin", size=20, downloaded=0, priority=0),
+        ]
+
+    app = _ScreenApp()
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(FileManagerScreen("Test Torrent", _empty))
+        await pilot.pause()
+        await pilot.pause()
+
+        await pilot.click("#file_manager_apply")
+        await pilot.pause()
+
+        # screen should still be open (no dismissal happened)
+        assert app.screen is not None
+        assert not worker.is_finished
+
+
+async def test_file_manager_load_error_dismisses():
+    def _raise() -> list[TorrentFileStatus] | None:
+        raise RuntimeError("boom")
+
+    app = _ScreenApp()
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(FileManagerScreen("Test Torrent", _raise))
+        await pilot.pause()
+        await pilot.pause()
+
+        assert await worker.wait() is None
+
+
+async def test_file_manager_loads_even_when_not_yet_mounted():
+    # Regression: the load worker can run before Textual sets is_mounted (the
+    # real app's event loop), which used to silently skip population forever.
+    app = _ScreenApp()
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(FileManagerScreen("Test Torrent", _load_status))
+        await pilot.pause()
+        await pilot.pause()
+
+        screen = app.screen
+        screen._is_mounted = False
+        await FileManagerScreen._load_data.__wrapped__(screen)
+
+        table = screen.query_one("#file_manager_table", AutoResizingDataTable)
+        assert table.row_count == 3
+        assert not table.has_class("hidden")
+        assert not worker.is_finished
+
+
+async def test_file_manager_waiting_for_metadata_then_populates():
+    calls = {"n": 0}
+
+    async def _flaky() -> list[TorrentFileStatus] | None:
+        calls["n"] += 1
+        return None if calls["n"] == 1 else STATUS
+
+    app = _ScreenApp()
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(FileManagerScreen("Test Torrent", _flaky))
+        await pilot.pause()
+        await pilot.pause()
+
+        screen = app.screen
+        table = screen.query_one("#file_manager_table", AutoResizingDataTable)
+        loader = screen.query_one("#file_manager_loader")
+        assert table.has_class("hidden")  # still waiting for metadata
+        assert not loader.has_class("hidden")
+
+        await screen._refresh()
+
+        assert table.row_count == 3
+        assert table.has_class("hidden") is False
+        assert not worker.is_finished
+
+
+async def test_file_manager_metadata_timeout_dismisses():
+    async def _never() -> list[TorrentFileStatus] | None:
+        return None
+
+    app = _ScreenApp()
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(
+            FileManagerScreen("Test Torrent", _never, metadata_timeout=0.0)
+        )
+        await pilot.pause()
+        await pilot.pause()
+
+        await app.screen._refresh()
+
+        assert await worker.wait() is None
+
+
+async def test_file_manager_refresh_error_keeps_table():
+    calls = {"n": 0}
+
+    async def _flaky() -> list[TorrentFileStatus] | None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return STATUS
+        raise RuntimeError("refresh boom")
+
+    app = _ScreenApp()
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(FileManagerScreen("Test Torrent", _flaky))
+        await pilot.pause()
+        await pilot.pause()
+
+        table = app.screen.query_one("#file_manager_table", AutoResizingDataTable)
+        assert table.row_count == 3
+
+        await app.screen._refresh()
+
+        assert table.row_count == 3
+        assert not worker.is_finished

--- a/tests/screens/test_file_selection.py
+++ b/tests/screens/test_file_selection.py
@@ -1,0 +1,250 @@
+import asyncio
+
+from textual import work
+from textual.app import App
+
+from torrra._types import TorrentFile
+from torrra.screens.file_selection import DOWNLOAD_ALL, FileSelectionScreen
+from torrra.widgets.file_tree import FileTree
+
+
+class _ScreenApp(App[None]):
+    @work(exclusive=True)
+    async def _open_and_wait(self, screen: FileSelectionScreen) -> None:
+        return await self.push_screen_wait(screen)
+
+
+FILES = [
+    TorrentFile(index=0, path="readme.txt", size=10),
+    TorrentFile(index=1, path="video.mp4", size=20),
+    TorrentFile(index=2, path="subs/en.srt", size=5),
+]
+
+
+async def _load_files() -> list[TorrentFile] | None:
+    return FILES
+
+
+async def test_file_selection_screen_lists_files():
+    app = _ScreenApp()
+    screen = FileSelectionScreen("Test Torrent", _load_files)
+
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(screen)
+        await pilot.pause()
+        await pilot.pause()
+
+        tree = screen.query_one("#file_selection_tree", FileTree)
+        assert not tree.has_class("hidden")
+        assert len(tree._file_nodes) == 3
+        assert "3 files" in str(screen.query_one("#file_selection_header").content)
+
+
+async def test_file_selection_confirm_returns_selected_indices():
+    app = _ScreenApp()
+    screen = FileSelectionScreen("Test Torrent", _load_files)
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(screen)
+        await pilot.pause()
+        await pilot.pause()
+
+        await pilot.press("j", "space")  # deselect video.mp4
+        await pilot.click("#download_button")
+
+        result = await worker.wait()
+        assert result == [0, 2]
+
+
+async def test_file_selection_cancel_returns_none():
+    app = _ScreenApp()
+    screen = FileSelectionScreen("Test Torrent", _load_files)
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(screen)
+        await pilot.pause()
+        await pilot.pause()
+
+        await pilot.click("#cancel_button")
+
+        assert await worker.wait() is None
+
+
+async def test_file_selection_escape_downloads_all():
+    app = _ScreenApp()
+    screen = FileSelectionScreen("Test Torrent", _load_files)
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(screen)
+        await pilot.pause()
+        await pilot.pause()
+
+        await pilot.press("escape")
+
+        assert await worker.wait() == DOWNLOAD_ALL
+
+
+async def test_file_selection_escape_during_loading():
+    async def _slow_load() -> list[TorrentFile] | None:
+        await asyncio.sleep(5)
+        return FILES
+
+    app = _ScreenApp()
+    screen = FileSelectionScreen("Test Torrent", _slow_load)
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(screen)
+        await pilot.pause()
+
+        await pilot.press("escape")
+
+        assert await worker.wait() == DOWNLOAD_ALL
+        assert screen._load_worker.is_cancelled
+
+
+async def test_file_selection_directory_toggle_selects_descendants():
+    app = _ScreenApp()
+    screen = FileSelectionScreen("Test Torrent", _load_files)
+
+    async with app.run_test() as pilot:
+        app._open_and_wait(screen)
+        await pilot.pause()
+        await pilot.pause()
+
+        tree = screen.query_one("#file_selection_tree", FileTree)
+        await pilot.press("j", "j")  # cursor to subs/ directory node
+        await pilot.press("space")  # deselect all descendants (en.srt)
+
+        assert tree.selected_indices() == [0, 1]
+
+        await pilot.press("space")  # re-select all descendants
+
+        assert tree.selected_indices() == [0, 1, 2]
+
+
+async def test_file_selection_blocks_empty_selection():
+    app = _ScreenApp()
+    screen = FileSelectionScreen("Test Torrent", _load_files)
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(screen)
+        await pilot.pause()
+        await pilot.pause()
+
+        await pilot.click("#select_none_button")
+        await pilot.pause()
+        await pilot.click("#download_button")
+
+        # screen should still be open (no dismissal happened)
+        assert screen.is_mounted
+        assert not worker.is_finished
+        assert app.screen is screen
+
+
+async def test_file_selection_tree_shows_markers():
+    app = _ScreenApp()
+    screen = FileSelectionScreen("Test Torrent", _load_files)
+
+    async with app.run_test() as pilot:
+        app._open_and_wait(screen)
+        await pilot.pause()
+        await pilot.pause()
+
+        tree = screen.query_one("#file_selection_tree", FileTree)
+        assert tree._file_nodes[0].label.plain.startswith("[x] readme.txt")
+        assert tree._file_nodes[1].label.plain.startswith("[x] video.mp4")
+
+        await pilot.press("j", "space")  # deselect video.mp4
+
+        assert tree._file_nodes[1].label.plain.startswith("[ ] video.mp4")
+        assert tree._file_nodes[0].label.plain.startswith("[x] readme.txt")
+
+
+async def test_file_selection_directory_markers():
+    async def _load_dir_files() -> list[TorrentFile] | None:
+        return [
+            TorrentFile(index=0, path="readme.txt", size=10),
+            TorrentFile(index=1, path="movies/a.mp4", size=20),
+            TorrentFile(index=2, path="movies/b.mp4", size=5),
+        ]
+
+    app = _ScreenApp()
+    screen = FileSelectionScreen("Test Torrent", _load_dir_files)
+
+    async with app.run_test() as pilot:
+        app._open_and_wait(screen)
+        await pilot.pause()
+        await pilot.pause()
+
+        tree = screen.query_one("#file_selection_tree", FileTree)
+        dir_node = tree._dir_nodes[("movies",)]
+        assert dir_node.label.plain.startswith("[x] movies/")
+
+        await pilot.press("j", "space")  # toggle movies/ dir off (all deselected)
+        assert dir_node.label.plain.startswith("[ ] movies/")
+        assert tree._file_nodes[1].label.plain.startswith("[ ] a.mp4")
+        assert tree._file_nodes[2].label.plain.startswith("[ ] b.mp4")
+
+        await pilot.press("space")  # re-select all descendants
+        assert dir_node.label.plain.startswith("[x] movies/")
+
+        await pilot.press("j", "space")  # deselect only a.mp4 (partial)
+        assert dir_node.label.plain.startswith("[-] movies/")
+
+
+async def test_file_selection_header_shows_selected_size():
+    app = _ScreenApp()
+    screen = FileSelectionScreen("Test Torrent", _load_files)
+
+    async with app.run_test() as pilot:
+        app._open_and_wait(screen)
+        await pilot.pause()
+        await pilot.pause()
+
+        header = screen.query_one("#file_selection_header")
+        assert "selected 35.00 B (3 files)" in str(header.content)
+
+        await pilot.press("j", "space")  # deselect video.mp4 (20 B)
+
+        assert "selected 15.00 B (2 files)" in str(header.content)
+
+        await pilot.press("space")  # re-select video.mp4
+
+        assert "selected 35.00 B (3 files)" in str(header.content)
+
+
+async def test_file_selection_tree_expand_collapse():
+    app = _ScreenApp()
+    screen = FileSelectionScreen("Test Torrent", _load_files)
+
+    async with app.run_test() as pilot:
+        app._open_and_wait(screen)
+        await pilot.pause()
+        await pilot.pause()
+
+        tree = screen.query_one("#file_selection_tree", FileTree)
+        dir_node = tree._dir_nodes[("subs",)]
+        assert dir_node.is_expanded
+
+        await pilot.press("j", "j")  # cursor to subs/ directory node
+        await pilot.press("left")  # collapse
+
+        assert not dir_node.is_expanded
+
+        await pilot.press("right")  # expand
+
+        assert dir_node.is_expanded
+
+
+async def test_file_selection_metadata_failure_dismisses():
+    async def _fail() -> list[TorrentFile] | None:
+        return None
+
+    app = _ScreenApp()
+    screen = FileSelectionScreen("Test Torrent", _fail)
+
+    async with app.run_test() as pilot:
+        worker = app._open_and_wait(screen)
+        await pilot.pause()
+
+        assert await worker.wait() is None

--- a/tests/test_core_torrent.py
+++ b/tests/test_core_torrent.py
@@ -1,0 +1,87 @@
+import pytest
+
+from torrra._types import Torrent
+from torrra.core.download import selection_priorities
+from torrra.core.torrent import TorrentManager
+
+
+@pytest.fixture
+def tm(tmp_path, monkeypatch):
+    from torrra.core import db as db_module
+    from torrra.core.db import init_db
+
+    monkeypatch.setattr(db_module, "DB_DIR", tmp_path)
+    monkeypatch.setattr(db_module, "DB_FILE", tmp_path / "torrra.db")
+    init_db()
+    return TorrentManager()
+
+
+def _torrent(uri="magnet:?xt=urn:btih:abc", selected_files=None) -> Torrent:
+    return Torrent(
+        magnet_uri=uri,
+        title="Example",
+        size=123.0,
+        seeders=0,
+        leechers=0,
+        source="test",
+        selected_files=selected_files,
+    )
+
+
+def test_add_and_load_selected_files(tm):
+    tm.add_torrent(_torrent(selected_files=[0, 2]))
+
+    records = tm.get_all_torrents()
+    assert len(records) == 1
+    assert records[0]["selected_files"] == [0, 2]
+
+
+def test_add_and_load_without_selection(tm):
+    tm.add_torrent(_torrent(selected_files=None))
+
+    records = tm.get_all_torrents()
+    assert records[0]["selected_files"] is None
+
+
+def test_load_malformed_selection_is_none(tm):
+    tm.add_torrent(_torrent(selected_files=[1]))
+
+    from torrra.core.db import get_db_connection
+
+    with get_db_connection() as conn:
+        conn.execute(
+            "UPDATE torrents SET selected_files = 'not-json' WHERE magnet_uri = ?",
+            ("magnet:?xt=urn:btih:abc",),
+        )
+        conn.commit()
+
+    records = tm.get_all_torrents()
+    assert records[0]["selected_files"] is None
+
+
+def test_selection_priorities_builds_partial_vector():
+    assert selection_priorities([0, 2]) == [1, 0, 1]
+    assert selection_priorities([4]) == [0, 0, 0, 0, 1]
+
+
+def test_selection_priorities_none_or_empty():
+    assert selection_priorities(None) is None
+    assert selection_priorities([]) is None
+
+
+def test_update_selected_files_persists(tm):
+    tm.add_torrent(_torrent(selected_files=[0, 2]))
+
+    tm.update_torrent_selected_files("magnet:?xt=urn:btih:abc", [1])
+
+    records = tm.get_all_torrents()
+    assert records[0]["selected_files"] == [1]
+
+
+def test_update_selected_files_clears_selection(tm):
+    tm.add_torrent(_torrent(selected_files=[0, 2]))
+
+    tm.update_torrent_selected_files("magnet:?xt=urn:btih:abc", None)
+
+    records = tm.get_all_torrents()
+    assert records[0]["selected_files"] is None

--- a/tests/test_download_flow.py
+++ b/tests/test_download_flow.py
@@ -1,0 +1,176 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from torrra._types import TorrentFile
+from torrra.screens.file_selection import DOWNLOAD_ALL
+from torrra.utils.download_flow import start_download
+
+
+async def test_start_download_download_all_without_metadata_skips_prioritize():
+    dm = MagicMock()
+    dm.get_files.return_value = None
+    dm.get_metadata.return_value = None
+    worker = MagicMock()
+    worker.wait = AsyncMock(return_value=DOWNLOAD_ALL)
+    app = MagicMock()
+    app._run_file_selection.return_value = worker
+
+    config = MagicMock()
+    config.get.return_value = True
+
+    with (
+        patch("torrra.utils.download_flow.get_download_manager", return_value=dm),
+        patch("torrra.utils.download_flow.get_config", return_value=config),
+    ):
+        result = await start_download(
+            app,
+            magnet_uri="magnet:?xt=urn:btih:abc",
+            title="Example",
+            source="jackett",
+        )
+
+    assert result is not None
+    dm.prioritize_files.assert_not_called()
+    dm.resume_torrent.assert_called_once_with("magnet:?xt=urn:btih:abc")
+
+
+async def test_start_download_download_all_with_metadata_prioritizes_everything():
+    dm = MagicMock()
+    dm.get_files.return_value = [
+        TorrentFile(index=0, path="a.txt", size=10),
+        TorrentFile(index=1, path="b.bin", size=20),
+    ]
+    dm.get_metadata.return_value = None
+    worker = MagicMock()
+    worker.wait = AsyncMock(return_value=DOWNLOAD_ALL)
+    app = MagicMock()
+    app._run_file_selection.return_value = worker
+
+    config = MagicMock()
+    config.get.return_value = True
+
+    with (
+        patch("torrra.utils.download_flow.get_download_manager", return_value=dm),
+        patch("torrra.utils.download_flow.get_config", return_value=config),
+    ):
+        result = await start_download(
+            app,
+            magnet_uri="magnet:?xt=urn:btih:abc",
+            title="Example",
+            source="jackett",
+        )
+
+    assert result is not None
+    dm.prioritize_files.assert_called_once_with("magnet:?xt=urn:btih:abc", {0, 1})
+    dm.resume_torrent.assert_called_once_with("magnet:?xt=urn:btih:abc")
+
+
+async def test_start_download_cancel_removes_torrent():
+    dm = MagicMock()
+    dm.get_metadata.return_value = None
+    worker = MagicMock()
+    worker.wait = AsyncMock(return_value=None)
+    app = MagicMock()
+    app._run_file_selection.return_value = worker
+
+    config = MagicMock()
+    config.get.return_value = True
+
+    with (
+        patch("torrra.utils.download_flow.get_download_manager", return_value=dm),
+        patch("torrra.utils.download_flow.get_config", return_value=config),
+    ):
+        result = await start_download(
+            app,
+            magnet_uri="magnet:?xt=urn:btih:abc",
+            title="Example",
+            source="jackett",
+        )
+
+    assert result is None
+    dm.remove_torrent.assert_called_once_with("magnet:?xt=urn:btih:abc")
+    dm.resume_torrent.assert_not_called()
+    dm.prioritize_files.assert_not_called()
+
+
+async def test_start_download_selection_records_selected_files():
+    dm = MagicMock()
+    dm.prioritize_files.return_value = True
+    dm.get_metadata.return_value = None
+    worker = MagicMock()
+    worker.wait = AsyncMock(return_value=[0, 2])
+    app = MagicMock()
+    app._run_file_selection.return_value = worker
+
+    config = MagicMock()
+    config.get.return_value = True
+
+    with (
+        patch("torrra.utils.download_flow.get_download_manager", return_value=dm),
+        patch("torrra.utils.download_flow.get_config", return_value=config),
+    ):
+        result = await start_download(
+            app,
+            magnet_uri="magnet:?xt=urn:btih:abc",
+            title="Example",
+            source="jackett",
+        )
+
+    assert result is not None
+    assert result.selected_files == [0, 2]
+    dm.prioritize_files.assert_called_once_with("magnet:?xt=urn:btih:abc", {0, 2})
+    dm.resume_torrent.assert_called_once_with("magnet:?xt=urn:btih:abc")
+
+
+async def test_start_download_download_all_has_no_selected_files():
+    dm = MagicMock()
+    dm.get_files.return_value = None
+    dm.get_metadata.return_value = None
+    worker = MagicMock()
+    worker.wait = AsyncMock(return_value=DOWNLOAD_ALL)
+    app = MagicMock()
+    app._run_file_selection.return_value = worker
+
+    config = MagicMock()
+    config.get.return_value = True
+
+    with (
+        patch("torrra.utils.download_flow.get_download_manager", return_value=dm),
+        patch("torrra.utils.download_flow.get_config", return_value=config),
+    ):
+        result = await start_download(
+            app,
+            magnet_uri="magnet:?xt=urn:btih:abc",
+            title="Example",
+            source="jackett",
+        )
+
+    assert result is not None
+    assert result.selected_files is None
+
+
+async def test_start_download_prioritize_failure_removes_without_resume():
+    dm = MagicMock()
+    dm.prioritize_files.return_value = False
+    worker = MagicMock()
+    worker.wait = AsyncMock(return_value=[0])
+    app = MagicMock()
+    app._run_file_selection.return_value = worker
+
+    config = MagicMock()
+    config.get.return_value = True
+
+    with (
+        patch("torrra.utils.download_flow.get_download_manager", return_value=dm),
+        patch("torrra.utils.download_flow.get_config", return_value=config),
+    ):
+        result = await start_download(
+            app,
+            magnet_uri="magnet:?xt=urn:btih:abc",
+            title="Example",
+            source="jackett",
+        )
+
+    assert result is None
+    dm.remove_torrent.assert_called_once_with("magnet:?xt=urn:btih:abc")
+    dm.resume_torrent.assert_not_called()
+    app.notify.assert_called_once()

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -1,0 +1,396 @@
+from unittest.mock import MagicMock
+
+from torrra._types import TorrentFile
+from torrra.core.download import DownloadManager, build_priorities
+
+
+def test_build_priorities_selects_only_selected():
+    assert build_priorities(5, {0, 3}) == [1, 0, 0, 1, 0]
+
+
+def test_build_priorities_empty_selection():
+    assert build_priorities(3, set()) == [0, 0, 0]
+
+
+def test_build_priorities_all_selected():
+    assert build_priorities(4, {0, 1, 2, 3}) == [1, 1, 1, 1]
+
+
+def _make_torrent_info(
+    file_specs: list[tuple[str, int]], name: str = "torrent", total_size: int = 30
+) -> MagicMock:
+    info = MagicMock()
+    info.name.return_value = name
+    info.total_size.return_value = total_size
+    storage = MagicMock()
+    storage.num_files.return_value = len(file_specs)
+    storage.file_path.side_effect = [spec[0] for spec in file_specs]
+    storage.file_size.side_effect = [spec[1] for spec in file_specs]
+    info.files.return_value = storage
+    return info
+
+
+def _make_handle(has_metadata: bool | None = None) -> MagicMock:
+    handle = MagicMock()
+    handle.is_valid.return_value = True
+    if has_metadata is not None:
+        handle.has_metadata.return_value = has_metadata
+    return handle
+
+
+def _make_manager(handle: MagicMock) -> DownloadManager:
+    manager = DownloadManager.__new__(DownloadManager)
+    manager.session = MagicMock()
+    manager.torrents = {"uri": handle}
+    manager._metadata_updated = set()
+    return manager
+
+
+def _make_status(**kwargs) -> MagicMock:
+    status = MagicMock()
+    for key, value in kwargs.items():
+        setattr(status, key, value)
+    return status
+
+
+def test_get_torrent_status_reports_zero_download_when_finished():
+    from torrra.core import download as download_module
+
+    handle = _make_handle()
+    handle.status.return_value = _make_status(
+        is_seeding=False,
+        is_finished=True,
+        state=download_module.lt.torrent_status.states.finished,
+        total_wanted=100,
+        total_wanted_done=100,
+        download_rate=6000.0,
+        upload_rate=185.0,
+        progress=1.0,
+        num_seeds=5,
+        num_peers=3,
+        flags=0,
+    )
+    manager = _make_manager(handle)
+
+    result = manager.get_torrent_status("uri")
+
+    assert result["down_speed"] == 0.0
+    assert result["up_speed"] == 185.0
+    assert result["is_seeding"] is True
+    assert result["eta"] is None
+
+
+def test_get_torrent_status_reports_download_speed_while_downloading():
+    from torrra.core import download as download_module
+
+    handle = _make_handle()
+    handle.status.return_value = _make_status(
+        is_seeding=False,
+        is_finished=False,
+        state=download_module.lt.torrent_status.states.downloading,
+        total_wanted=1000,
+        total_wanted_done=500,
+        download_rate=6000.0,
+        upload_rate=0.0,
+        progress=0.5,
+        num_seeds=2,
+        num_peers=4,
+        flags=0,
+    )
+    manager = _make_manager(handle)
+
+    result = manager.get_torrent_status("uri")
+
+    assert result["down_speed"] == 6000.0
+    assert result["eta"] == 500 / 6000.0
+    assert result["is_seeding"] is False
+
+
+def test_get_files_returns_none_without_metadata():
+    handle = _make_handle(has_metadata=False)
+    manager = _make_manager(handle)
+
+    assert manager.get_files("uri") is None
+
+
+def test_get_files_returns_file_list_with_metadata():
+    handle = _make_handle(has_metadata=True)
+    handle.torrent_file.return_value = _make_torrent_info(
+        [("a.txt", 10), ("sub/b.bin", 20)]
+    )
+    manager = _make_manager(handle)
+
+    assert manager.get_files("uri") == [
+        TorrentFile(index=0, path="a.txt", size=10),
+        TorrentFile(index=1, path="sub/b.bin", size=20),
+    ]
+
+
+def test_get_file_details_returns_progress_and_priorities():
+    handle = _make_handle(has_metadata=True)
+    handle.torrent_file.return_value = _make_torrent_info(
+        [("a.txt", 10), ("b.bin", 20)], total_size=30
+    )
+    handle.file_progress.return_value = [10, 5]
+    handle.file_priorities.return_value = [1, 0]
+    manager = _make_manager(handle)
+
+    details = manager.get_file_details("uri")
+
+    assert details is not None
+    assert len(details) == 2
+    assert details[0].index == 0
+    assert details[0].path == "a.txt"
+    assert details[0].size == 10
+    assert details[0].downloaded == 10
+    assert details[0].priority == 1
+    assert details[1].downloaded == 5
+    assert details[1].priority == 0
+
+
+def test_get_file_details_falls_back_when_progress_fails():
+    handle = _make_handle(has_metadata=True)
+    handle.torrent_file.return_value = _make_torrent_info(
+        [("a.txt", 10)], total_size=10
+    )
+    handle.file_progress.side_effect = RuntimeError
+    handle.file_priorities.side_effect = RuntimeError
+    manager = _make_manager(handle)
+
+    details = manager.get_file_details("uri")
+
+    assert details is not None
+    assert details[0].downloaded == 0
+    assert details[0].priority == 0
+
+
+def test_get_file_details_returns_none_without_metadata():
+    handle = _make_handle(has_metadata=False)
+    manager = _make_manager(handle)
+
+    assert manager.get_file_details("uri") is None
+    handle.file_progress.assert_not_called()
+
+
+def test_get_metadata_returns_name_and_total_size():
+    handle = _make_handle(has_metadata=True)
+    handle.torrent_file.return_value = _make_torrent_info(
+        [("a.txt", 10)], name="my-torrent", total_size=10
+    )
+    manager = _make_manager(handle)
+
+    assert manager.get_metadata("uri") == ("my-torrent", 10)
+
+
+def test_prioritize_files_applies_selected_priorities():
+    handle = _make_handle(has_metadata=True)
+    handle.torrent_file.return_value = _make_torrent_info(
+        [("a.txt", 10), ("b.bin", 20), ("c.iso", 30)]
+    )
+    manager = _make_manager(handle)
+
+    assert manager.prioritize_files("uri", {0, 2}) is True
+    handle.prioritize_files.assert_called_once_with([1, 0, 1])
+
+
+def test_prioritize_files_returns_false_without_metadata():
+    handle = _make_handle(has_metadata=False)
+    manager = _make_manager(handle)
+
+    assert manager.prioritize_files("uri", {0}) is False
+    handle.prioritize_files.assert_not_called()
+
+
+def test_resume_torrent():
+    handle = _make_handle()
+    manager = _make_manager(handle)
+
+    assert manager.resume_torrent("uri") is True
+    handle.unset_flags.assert_called_once_with(0x800002)
+    handle.set_flags.assert_called_once_with(0x20)
+    handle.resume.assert_called_once()
+
+
+async def test_wait_for_metadata_polls_until_available(fast_sleep):
+    calls = {"n": 0}
+    handle = _make_handle()
+
+    def fake_has_metadata() -> bool:
+        calls["n"] += 1
+        return calls["n"] >= 3
+
+    handle.has_metadata.side_effect = fake_has_metadata
+    handle.torrent_file.return_value = _make_torrent_info(
+        [("a.txt", 10), ("b.bin", 20)]
+    )
+    manager = _make_manager(handle)
+
+    result = await manager.wait_for_metadata("uri", timeout=5)
+
+    assert result == [
+        TorrentFile(index=0, path="a.txt", size=10),
+        TorrentFile(index=1, path="b.bin", size=20),
+    ]
+    assert calls["n"] >= 3
+
+
+async def test_wait_for_metadata_times_out(fast_sleep):
+    handle = _make_handle(has_metadata=False)
+    manager = _make_manager(handle)
+
+    result = await manager.wait_for_metadata("uri", timeout=0.01)
+
+    assert result is None
+
+
+def test_add_torrent_sets_torrent_info(monkeypatch):
+    from torrra.core import download as download_module
+
+    atp = MagicMock()
+    parse_magnet = MagicMock(return_value=atp)
+    handle = MagicMock()
+    handle.is_valid.return_value = False
+
+    class FakeFlags:
+        paused = 0x10
+        auto_managed = 0x20
+        upload_mode = 0x2
+        default_dont_download = 0x800000
+
+    class FakeSession:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def add_torrent(self, params):
+            return handle
+
+    class FakeLt:
+        parse_magnet_uri = staticmethod(parse_magnet)
+        torrent_flags = FakeFlags
+        session = FakeSession
+
+    monkeypatch.setattr(download_module, "lt", FakeLt)
+
+    manager = download_module.DownloadManager()
+    torrent_info = MagicMock()
+
+    manager.add_torrent("magnet:?xt=urn:btih:abc", torrent_info=torrent_info)
+
+    assert manager.torrents["magnet:?xt=urn:btih:abc"] is handle
+    assert atp.ti is torrent_info
+
+
+def test_add_torrent_metadata_only_sets_flags(monkeypatch):
+    from torrra.core import download as download_module
+
+    atp = MagicMock()
+    atp.flags = 0x20  # default_flags: auto_managed set, paused cleared
+    parse_magnet = MagicMock(return_value=atp)
+    handle = MagicMock()
+    handle.is_valid.return_value = False
+
+    class FakeFlags:
+        paused = 0x10
+        auto_managed = 0x20
+        upload_mode = 0x2
+        default_dont_download = 0x800000
+
+    class FakeSession:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def add_torrent(self, params):
+            return handle
+
+    class FakeLt:
+        parse_magnet_uri = staticmethod(parse_magnet)
+        torrent_flags = FakeFlags
+        session = FakeSession
+
+    monkeypatch.setattr(download_module, "lt", FakeLt)
+
+    manager = download_module.DownloadManager()
+
+    manager.add_torrent("magnet:?xt=urn:btih:abc", metadata_only=True)
+
+    assert manager.torrents["magnet:?xt=urn:btih:abc"] is handle
+    assert atp.flags == 0x800022
+    assert atp.flags & 0x10 == 0
+    assert atp.flags & 0x20 != 0
+
+
+def test_add_torrent_sets_file_priorities(monkeypatch):
+    from torrra.core import download as download_module
+
+    atp = MagicMock()
+    atp.flags = 0x0
+    parse_magnet = MagicMock(return_value=atp)
+    handle = MagicMock()
+    handle.is_valid.return_value = False
+
+    class FakeFlags:
+        paused = 0x10
+        auto_managed = 0x20
+        upload_mode = 0x2
+        default_dont_download = 0x800000
+
+    class FakeSession:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def add_torrent(self, params):
+            return handle
+
+    class FakeLt:
+        parse_magnet_uri = staticmethod(parse_magnet)
+        torrent_flags = FakeFlags
+        session = FakeSession
+
+    monkeypatch.setattr(download_module, "lt", FakeLt)
+
+    manager = download_module.DownloadManager()
+
+    manager.add_torrent(
+        "magnet:?xt=urn:btih:abc",
+        file_priorities=[1, 0, 1],
+    )
+
+    assert atp.file_priorities == [1, 0, 1]
+    assert atp.flags & 0x800000 != 0
+
+
+def test_add_torrent_without_file_priorities_leaves_vector_empty(monkeypatch):
+    from torrra.core import download as download_module
+
+    atp = MagicMock()
+    atp.flags = 0x20
+    parse_magnet = MagicMock(return_value=atp)
+    handle = MagicMock()
+    handle.is_valid.return_value = False
+
+    class FakeFlags:
+        paused = 0x10
+        auto_managed = 0x20
+        upload_mode = 0x2
+        default_dont_download = 0x800000
+
+    class FakeSession:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def add_torrent(self, params):
+            return handle
+
+    class FakeLt:
+        parse_magnet_uri = staticmethod(parse_magnet)
+        torrent_flags = FakeFlags
+        session = FakeSession
+
+    monkeypatch.setattr(download_module, "lt", FakeLt)
+
+    manager = download_module.DownloadManager()
+
+    manager.add_torrent("magnet:?xt=urn:btih:abc")
+
+    assert "file_priorities" not in atp.__dict__
+    assert atp.flags & 0x800000 == 0

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,0 +1,117 @@
+from unittest.mock import MagicMock, patch
+
+from textual.app import App
+
+from torrra._types import Indexer, TorrentFileStatus
+from torrra.screens import home as home_module
+from torrra.screens.home import HomeScreen
+from torrra.widgets import downloads as downloads_module
+from torrra.widgets.downloads import DownloadsContent
+
+RECORDS = [
+    {
+        "magnet_uri": "magnet:?xt=urn:btih:abc",
+        "title": "Selective",
+        "size": 100.0,
+        "source": "test",
+        "is_paused": False,
+        "is_notified": False,
+        "selected_files": [0, 2],
+    },
+    {
+        "magnet_uri": "magnet:?xt=urn:btih:def",
+        "title": "Full",
+        "size": 200.0,
+        "source": "test",
+        "is_paused": True,
+        "is_notified": False,
+        "selected_files": None,
+    },
+]
+
+
+class _Harness(App[None]):
+    def compose(self):
+        yield HomeScreen(
+            indexer=Indexer(
+                name="jackett",
+                url="http://mock.indexer.url",
+                api_key="mock_api_key",
+            ),
+            search_query="",
+            use_cache=False,
+        )
+
+
+async def test_startup_restore_applies_saved_selection_priorities():
+    dm = MagicMock()
+    dm.torrents = {}
+    tm = MagicMock()
+    tm.get_all_torrents.return_value = RECORDS
+
+    with (
+        patch.object(home_module, "get_download_manager", return_value=dm),
+        patch.object(home_module, "get_torrent_manager", return_value=tm),
+    ):
+        async with _Harness().run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+
+    dm.add_torrent.assert_any_call(
+        "magnet:?xt=urn:btih:abc",
+        is_paused=False,
+        file_priorities=[1, 0, 1],
+    )
+    dm.add_torrent.assert_any_call(
+        "magnet:?xt=urn:btih:def",
+        is_paused=True,
+        file_priorities=None,
+    )
+
+
+async def test_f_opens_file_manager_and_applies_selection():
+    from torrra.screens.file_manager import FileManagerScreen
+
+    dm = MagicMock()
+    dm.torrents = {}
+    dm.get_file_details.return_value = [
+        TorrentFileStatus(index=0, path="a.bin", size=10, downloaded=0, priority=1),
+        TorrentFileStatus(index=1, path="b.bin", size=20, downloaded=0, priority=0),
+    ]
+    dm.prioritize_files.return_value = True
+    tm = MagicMock()
+    tm.get_all_torrents.return_value = RECORDS
+
+    with (
+        patch.object(home_module, "get_download_manager", return_value=dm),
+        patch.object(home_module, "get_torrent_manager", return_value=tm),
+        patch.object(downloads_module, "get_download_manager", return_value=dm),
+        patch.object(downloads_module, "get_torrent_manager", return_value=tm),
+    ):
+        async with _Harness().run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+
+            downloads = pilot.app.query_one(DownloadsContent)
+            pilot.app.query_one("#content_switcher").current = "downloads_content"
+            await pilot.pause()
+            await pilot.pause()
+            downloads._selected_torrent = RECORDS[0]
+
+            assert ("f", "show_file_manager") in DownloadsContent.BINDINGS
+            downloads.action_show_file_manager()
+            await pilot.pause()
+            await pilot.pause()
+
+            assert isinstance(pilot.app.screen, FileManagerScreen)
+
+            table = pilot.app.screen.query_one("#file_manager_table")
+            table.move_cursor(row=1)  # b.bin (currently deselected)
+            await pilot.press("space")
+            await pilot.click("#file_manager_apply")
+            await pilot.pause()
+
+    dm.prioritize_files.assert_called_once_with("magnet:?xt=urn:btih:abc", {0, 1})
+    tm.update_torrent_selected_files.assert_called_once_with(
+        "magnet:?xt=urn:btih:abc", [0, 1]
+    )


### PR DESCRIPTION
## Summary

This PR adds per-file selection to torrra, both before a torrent starts and after it is already downloading or complete:

1. A file selection screen shown before download, so you can pick which files of a torrent to include.
2. A file manager available from the downloads view (press `f`) to review and change the selection at any time.
3. Persistence of the selection, so it survives restarts.

## Before download

When a torrent is added, torrra now shows a file selection screen (unless disabled):

- Files are shown in a directory tree, all selected by default.
- Toggle a single file with `Space` or `Enter`. Toggle a whole directory at once. Use **Select all** / **Select none** for bulk changes.
- Navigate with `j`/`k` and expand or collapse directories with the left and right arrow keys.
- Press **Download** to start with the selected files, **Cancel** to abort, or `Escape` to skip selection and download everything.

While metadata is fetched (for magnet URIs), the torrent runs in metadata-only mode with all files at `dont_download` priority, so nothing is written to disk until you confirm a selection.

The screen is shown for every entry point: search results, `torrra download <magnet>`, and `torrra download <file.torrent>`. It can be disabled with `general.select_files = false`.

## After download (file manager)

Press `f` on a torrent in the downloads view to open the file manager:

- A flat table lists every file with its selection state, size, bytes downloaded, and completion percentage.
- Toggle files with `Space`, move with `j`/`k`.
- **Apply** saves the new selection. It is applied to the running torrent immediately and persisted. **Close** or `Escape` exits without changes.
- An empty selection is refused, at least one file must remain selected.

The file manager works on running and completed torrents. If metadata is not available yet it waits and retries, and shows a clear error notification after a timeout instead of hanging.

## Persistence

The selected file indexes are stored with the download record (a new `selected_files` column). On restore, the selection is re-applied to the torrent, so a torrent never silently falls back to downloading every file after a restart.

## Bug fix

Fixes a race in the file manager where the loader could stay visible forever with no error. The load worker is now allowed to finish populating even when it starts before the screen reports itself mounted; load failures surface as an error notification instead of a silent hang.

## Known limitation

A deselected file that shares a piece boundary with a selected file may still have a few bytes downloaded. BitTorrent hashes pieces as a whole, and libtorrent documents that partial pieces may still be downloaded when setting file priorities. In libtorrent 2.1 the bytes for deselected files are buffered in a temporary `.parts` file and are not written to the deselected file, so the file is not created.

## Tests

Adds unit tests for the file selection screen, the file tree, the file manager, torrent file status, and selected-file persistence. Full suite: 97 passed.

## Docs

Usage docs describe both the pre-download selection and the file manager, with updated keyboard shortcuts in the TUI controls table.