### PR TITLE
feat: allow running direct download without indexer

### DIFF
--- a/src/torrra/__main__.py
+++ b/src/torrra/__main__.py
@@ -25,7 +25,7 @@ def download(magnet_uri_or_file: str, no_cache: bool) -> None:
     import os
     import re
 
-    from torrra.utils.indexer import run_with_default_indexer
+    from torrra.utils.indexer import run_without_indexer
 
     # Validate input - can be magnet URI, URL, or local torrent file
     is_magnet = magnet_uri_or_file.startswith("magnet:")
@@ -42,8 +42,8 @@ def download(magnet_uri_or_file: str, no_cache: bool) -> None:
         )
         return
 
-    # detect indexer from config and execute with direct download
-    run_with_default_indexer(no_cache=no_cache, direct_download=magnet_uri_or_file)
+    # direct download needs no indexer - launch straight into downloads
+    run_without_indexer(no_cache=no_cache, direct_download=magnet_uri_or_file)
 
 
 # --------------------------------------------------
@@ -65,10 +65,10 @@ def search(search_query: str, no_cache: bool) -> None:
 @cli.command(help="Show the downloads view directly.")
 @click.option("--no-cache", is_flag=True, help="Disable caching mechanism.")
 def downloads(no_cache: bool) -> None:
-    from torrra.utils.indexer import run_with_default_indexer
+    from torrra.utils.indexer import run_without_indexer
 
-    # detect indexer from config and execute with show_downloads
-    run_with_default_indexer(no_cache=no_cache, show_downloads=True)
+    # the downloads view needs no indexer - launch straight into it
+    run_without_indexer(no_cache=no_cache, show_downloads=True)
 
 
 # --------------------------------------------------

--- a/src/torrra/app.py
+++ b/src/torrra/app.py
@@ -30,14 +30,14 @@ class TorrraApp(App[None]):
 
     def __init__(
         self,
-        indexer: Indexer,
+        indexer: Indexer | None,
         use_cache: bool,
         search_query: str | None,
         direct_download: str | None = None,
         show_downloads: bool = False,
     ) -> None:
         super().__init__()
-        self.indexer: Indexer = indexer
+        self.indexer: Indexer | None = indexer
         self.use_cache: bool = use_cache
         self.search_query: str | None = search_query
         self.direct_download: str | None = direct_download
@@ -53,29 +53,21 @@ class TorrraApp(App[None]):
         self.theme = theme
 
     async def on_mount(self) -> None:
-        if self.direct_download:
-            # Direct download mode - go straight to home screen with downloads tab
+        # the welcome screen only exists to collect a search query, so it is
+        # reachable solely with a configured indexer and no other entry point
+        # (direct download / downloads view / an already-supplied query)
+        wants_downloads_view = bool(self.direct_download or self.show_downloads)
+        has_query = bool(self.search_query and self.search_query.strip())
+
+        if self.indexer is not None and not wants_downloads_view and not has_query:
+            self._show_welcome_and_search()
+        else:
             await self.push_screen(
                 HomeScreen(
                     indexer=self.indexer,
                     search_query=self.search_query or "",
                     use_cache=self.use_cache,
                     direct_download=self.direct_download,
-                    show_downloads=self.show_downloads,
-                )
-            )
-        elif (
-            not (self.search_query and self.search_query.strip())
-            and not self.show_downloads
-        ):
-            self._show_welcome_and_search()
-        else:  # direct show search screen
-            await self.push_screen(
-                HomeScreen(
-                    indexer=self.indexer,
-                    search_query=self.search_query or "",
-                    use_cache=self.use_cache,
-                    direct_download=None,
                     show_downloads=self.show_downloads,
                 )
             )
@@ -101,6 +93,8 @@ class TorrraApp(App[None]):
 
     @work(exclusive=True)
     async def _show_welcome_and_search(self) -> None:
+        # only ever called with an indexer configured (see on_mount)
+        assert self.indexer is not None
         if search_query := await self.push_screen_wait(
             WelcomeScreen(indexer=self.indexer)
         ):  # show both screens

--- a/src/torrra/core/torrent.py
+++ b/src/torrra/core/torrent.py
@@ -15,6 +15,7 @@ def get_torrent_manager() -> "TorrentManager":
 class TorrentManager:
     def __init__(self) -> None:
         init_db()
+
     def add_torrent(
         self, torrent: Torrent, file_priorities: list[int] | None = None
     ) -> None:

--- a/src/torrra/core/torrent.py
+++ b/src/torrra/core/torrent.py
@@ -13,6 +13,8 @@ def get_torrent_manager() -> "TorrentManager":
 
 
 class TorrentManager:
+    def __init__(self) -> None:
+        init_db()
     def add_torrent(
         self, torrent: Torrent, file_priorities: list[int] | None = None
     ) -> None:

--- a/src/torrra/screens/home.py
+++ b/src/torrra/screens/home.py
@@ -15,14 +15,14 @@ from torrra.widgets.sidebar import Sidebar
 class HomeScreen(Screen[None]):
     def __init__(
         self,
-        indexer: Indexer,
+        indexer: Indexer | None,
         search_query: str,
         use_cache: bool,
         direct_download: str | None = None,
         show_downloads: bool = False,
     ):
         super().__init__()
-        self.indexer: Indexer = indexer
+        self.indexer: Indexer | None = indexer
         self.search_query: str = search_query
         self.use_cache: bool = use_cache
         self.direct_download: str | None = direct_download
@@ -34,21 +34,24 @@ class HomeScreen(Screen[None]):
 
     @override
     def compose(self) -> ComposeResult:
+        # without an indexer there is no search, so the app opens on downloads
+        has_search = self.indexer is not None
         initial_content = (
-            "downloads_content"
-            if self.direct_download or self.show_downloads
-            else "search_content"
+            "search_content"
+            if has_search and not (self.direct_download or self.show_downloads)
+            else "downloads_content"
         )
 
         with Horizontal(id="main_layout"):
-            yield Sidebar(id="sidebar")
+            yield Sidebar(id="sidebar", show_search=has_search)
             with ContentSwitcher(initial=initial_content, id="content_switcher"):
                 yield DownloadsContent()
-                yield SearchContent(
-                    indexer=self.indexer,
-                    search_query=self.search_query,
-                    use_cache=self.use_cache,
-                )
+                if self.indexer is not None:
+                    yield SearchContent(
+                        indexer=self.indexer,
+                        search_query=self.search_query,
+                        use_cache=self.use_cache,
+                    )
 
     def on_mount(self) -> None:
         self._sidebar = self.query_one(Sidebar)
@@ -67,7 +70,7 @@ class HomeScreen(Screen[None]):
                 file_priorities=torrent.get("file_priorities"),
             )
 
-        if self.show_downloads or self.direct_download:
+        if self.show_downloads or self.direct_download or self.indexer is None:
             # When showing downloads or handling direct download, set sidebar active node to downloads
             self._sidebar.select_node_by_group_id("downloads_content")
             self._downloads_content.focus_table()

--- a/src/torrra/utils/indexer.py
+++ b/src/torrra/utils/indexer.py
@@ -97,6 +97,41 @@ def run_with_indexer(
         click.secho(str(e), fg="red", err=True)
 
 
+def run_without_indexer(
+    *,
+    no_cache: bool,
+    direct_download: str | None = None,
+    show_downloads: bool = False,
+) -> None:
+    """Launch the app without an indexer.
+
+    Used by entry points that only touch downloads - `torrra download` and
+    `torrra downloads`. These never search, so no indexer needs to be
+    configured or health-checked; the app opens straight to the downloads
+    view with search disabled.
+    """
+    config = get_config()
+
+    # load app only when needed (heavy stuff)
+    from torrra.app import TorrraApp
+
+    try:
+        use_cache = config.get("general.use_cache", True)
+        if no_cache:  # --no-cache flag overrides config
+            use_cache = False
+
+        app = TorrraApp(
+            indexer=None,
+            use_cache=use_cache,
+            search_query=None,
+            direct_download=direct_download,
+            show_downloads=show_downloads,
+        )
+        app.run()
+    except RuntimeError as e:
+        click.secho(str(e), fg="red", err=True)
+
+
 def run_with_default_indexer(
     *,
     no_cache: bool,

--- a/src/torrra/widgets/sidebar.py
+++ b/src/torrra/widgets/sidebar.py
@@ -29,12 +29,13 @@ class Sidebar(Tree[Any]):
             self.group_type: str | None = group_type
             super().__init__()
 
-    def __init__(self, id: str) -> None:
+    def __init__(self, id: str, show_search: bool = True) -> None:
         super().__init__("Menu", id=id)
         self.show_horizontal_scrollbar: Reactive[bool] = reactive(False)
         self.show_root: bool = False
         self.guide_depth: int = 3
         self.can_focus: bool = False  # re-enable focus later
+        self._show_search: bool = show_search
 
         self._downloads_root_node: TreeNode[Any]
         self._downloads_nodes: dict[str, TreeNode[Any]] = {}
@@ -43,8 +44,13 @@ class Sidebar(Tree[Any]):
     def compose(self) -> ComposeResult:
         root = self.root
         # NODES
-        search = root.add("Search", allow_expand=False)
-        search.data = {"group_id": "search_content"}
+        # search is only offered when an indexer is configured; downloads-only
+        # entry points (torrra download / torrra downloads) hide it
+        default_node: TreeNode[Any] | None = None
+        if self._show_search:
+            search = root.add("Search", allow_expand=False)
+            search.data = {"group_id": "search_content"}
+            default_node = search
 
         downloads_node = root.add("Downloads (0)", expand=True, allow_expand=False)
         downloads_node.data = {"group_id": "downloads_content"}
@@ -56,7 +62,8 @@ class Sidebar(Tree[Any]):
             self._downloads_nodes[item] = node
         self._downloads_root_node = downloads_node
 
-        self.select_node(search)  # default
+        # fall back to downloads as the default when search is hidden
+        self.select_node(default_node or downloads_node)
         return super().compose()
 
     def on_tree_node_selected(self, event: Tree.NodeSelected[dict[str, str]]) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,30 @@ import pytest
 from torrra._types import Indexer
 from torrra.app import TorrraApp
 from torrra.core import config as config_module
+from torrra.core import db as db_module
 from torrra.core.config import Config
+from torrra.core.download import get_download_manager
+from torrra.core.torrent import get_torrent_manager
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # Ensure every test runs with an isolated database and clean managers
+    temp_db_dir = tmp_path / "torrra_db"
+    temp_db_file = temp_db_dir / "torrra.db"
+
+    monkeypatch.setattr(db_module, "DB_DIR", temp_db_dir)
+    monkeypatch.setattr(db_module, "DB_FILE", temp_db_file)
+
+    get_torrent_manager.cache_clear()
+    get_download_manager.cache_clear()
+
+    db_module.init_db()
+
+    yield temp_db_file
+
+    get_torrent_manager.cache_clear()
+    get_download_manager.cache_clear()
 
 
 @pytest.fixture

--- a/tests/screens/test_downloads_only.py
+++ b/tests/screens/test_downloads_only.py
@@ -1,23 +1,11 @@
-from typing import Any
-
-import pytest
 from textual.widgets import ContentSwitcher
 
 from torrra.app import TorrraApp
-from torrra.core import db as db_module
 from torrra.screens.file_selection import FileSelectionScreen
 from torrra.screens.home import HomeScreen
 from torrra.widgets.downloads import DownloadsContent
 from torrra.widgets.search import SearchContent
 from torrra.widgets.sidebar import Sidebar
-
-
-@pytest.fixture
-def temp_db(tmp_path: Any, monkeypatch: pytest.MonkeyPatch):
-    # downloads machinery touches the db on mount, so point it at a temp file
-    monkeypatch.setattr(db_module, "DB_FILE", tmp_path / "test.db")
-    monkeypatch.setattr(db_module, "DB_DIR", tmp_path)
-    db_module.init_db()
 
 
 def _sidebar_group_ids(sidebar: Sidebar) -> list[str | None]:
@@ -27,7 +15,6 @@ def _sidebar_group_ids(sidebar: Sidebar) -> list[str | None]:
     ]
 
 
-@pytest.mark.usefixtures("temp_db")
 async def test_downloads_view_launches_without_indexer():
     # `torrra downloads` - no indexer configured
     app = TorrraApp(
@@ -53,7 +40,6 @@ async def test_downloads_view_launches_without_indexer():
         ]
 
 
-@pytest.mark.usefixtures("temp_db")
 async def test_direct_download_launches_without_indexer():
     # `torrra download <magnet>` - no indexer configured
     magnet = "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567&dn=test"
@@ -78,7 +64,6 @@ async def test_direct_download_launches_without_indexer():
         assert _sidebar_group_ids(home.query_one(Sidebar)) == ["downloads_content"]
 
 
-@pytest.mark.usefixtures("temp_db")
 async def test_downloads_view_never_reaches_welcome_without_indexer():
     # a bare downloads launch (no flags) must still skip the welcome/search
     # screen entirely rather than crash on the missing indexer
@@ -91,7 +76,6 @@ async def test_downloads_view_never_reaches_welcome_without_indexer():
         assert len(app.screen.query(SearchContent)) == 0
 
 
-@pytest.mark.usefixtures("temp_db")
 async def test_downloads_content_is_interactive_without_indexer():
     # the downloads table should take focus so it is immediately usable
     app = TorrraApp(

--- a/tests/screens/test_downloads_only.py
+++ b/tests/screens/test_downloads_only.py
@@ -21,7 +21,10 @@ def temp_db(tmp_path: Any, monkeypatch: pytest.MonkeyPatch):
 
 
 def _sidebar_group_ids(sidebar: Sidebar) -> list[str | None]:
-    return [child.data.get("group_id") if child.data else None for child in sidebar.root.children]
+    return [
+        child.data.get("group_id") if child.data else None
+        for child in sidebar.root.children
+    ]
 
 
 @pytest.mark.usefixtures("temp_db")
@@ -45,7 +48,9 @@ async def test_downloads_view_launches_without_indexer():
         )
         # ...and search is entirely absent, both content and sidebar node
         assert len(app.screen.query(SearchContent)) == 0
-        assert _sidebar_group_ids(app.screen.query_one(Sidebar)) == ["downloads_content"]
+        assert _sidebar_group_ids(app.screen.query_one(Sidebar)) == [
+            "downloads_content"
+        ]
 
 
 @pytest.mark.usefixtures("temp_db")

--- a/tests/screens/test_downloads_only.py
+++ b/tests/screens/test_downloads_only.py
@@ -1,0 +1,103 @@
+from typing import Any
+
+import pytest
+from textual.widgets import ContentSwitcher
+
+from torrra.app import TorrraApp
+from torrra.core import db as db_module
+from torrra.screens.file_selection import FileSelectionScreen
+from torrra.screens.home import HomeScreen
+from torrra.widgets.downloads import DownloadsContent
+from torrra.widgets.search import SearchContent
+from torrra.widgets.sidebar import Sidebar
+
+
+@pytest.fixture
+def temp_db(tmp_path: Any, monkeypatch: pytest.MonkeyPatch):
+    # downloads machinery touches the db on mount, so point it at a temp file
+    monkeypatch.setattr(db_module, "DB_FILE", tmp_path / "test.db")
+    monkeypatch.setattr(db_module, "DB_DIR", tmp_path)
+    db_module.init_db()
+
+
+def _sidebar_group_ids(sidebar: Sidebar) -> list[str | None]:
+    return [child.data.get("group_id") if child.data else None for child in sidebar.root.children]
+
+
+@pytest.mark.usefixtures("temp_db")
+async def test_downloads_view_launches_without_indexer():
+    # `torrra downloads` - no indexer configured
+    app = TorrraApp(
+        indexer=None,
+        use_cache=False,
+        search_query=None,
+        show_downloads=True,
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        assert isinstance(app.screen, HomeScreen)
+        # the downloads tab is active...
+        assert (
+            app.screen.query_one("#content_switcher", ContentSwitcher).current
+            == "downloads_content"
+        )
+        # ...and search is entirely absent, both content and sidebar node
+        assert len(app.screen.query(SearchContent)) == 0
+        assert _sidebar_group_ids(app.screen.query_one(Sidebar)) == ["downloads_content"]
+
+
+@pytest.mark.usefixtures("temp_db")
+async def test_direct_download_launches_without_indexer():
+    # `torrra download <magnet>` - no indexer configured
+    magnet = "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567&dn=test"
+    app = TorrraApp(
+        indexer=None,
+        use_cache=False,
+        search_query=None,
+        direct_download=magnet,
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        # the file-selection modal opens over a downloads-only home screen
+        assert isinstance(app.screen, FileSelectionScreen)
+        home = next(s for s in app.screen_stack if isinstance(s, HomeScreen))
+        assert (
+            home.query_one("#content_switcher", ContentSwitcher).current
+            == "downloads_content"
+        )
+        assert len(home.query(SearchContent)) == 0
+        assert _sidebar_group_ids(home.query_one(Sidebar)) == ["downloads_content"]
+
+
+@pytest.mark.usefixtures("temp_db")
+async def test_downloads_view_never_reaches_welcome_without_indexer():
+    # a bare downloads launch (no flags) must still skip the welcome/search
+    # screen entirely rather than crash on the missing indexer
+    app = TorrraApp(indexer=None, use_cache=False, search_query=None)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        assert isinstance(app.screen, HomeScreen)
+        assert len(app.screen.query(SearchContent)) == 0
+
+
+@pytest.mark.usefixtures("temp_db")
+async def test_downloads_content_is_interactive_without_indexer():
+    # the downloads table should take focus so it is immediately usable
+    app = TorrraApp(
+        indexer=None,
+        use_cache=False,
+        search_query=None,
+        show_downloads=True,
+    )
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        downloads = app.screen.query_one(DownloadsContent)
+        assert downloads._table.has_focus

--- a/tests/screens/test_file_selection.py
+++ b/tests/screens/test_file_selection.py
@@ -481,6 +481,7 @@ async def test_direct_download_modal_shown_on_downloads_section(
         )
         sidebar = home_screen.query_one("#sidebar", Sidebar)
         assert sidebar.cursor_node is not None
+        assert sidebar.cursor_node.data is not None
         assert sidebar.cursor_node.data.get("group_id") == "downloads_content"
 
         # Confirm download with enter (skip metadata / download all)

--- a/tests/screens/test_welcome.py
+++ b/tests/screens/test_welcome.py
@@ -53,6 +53,7 @@ async def test_welcome_screen_version_display(app: TorrraApp):
 
         # version should be same
         assert __version__ in version_text
+        assert app.indexer is not None
         assert app.indexer.name in version_text
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,13 +78,14 @@ def test_config_commands_flow():
 
 def test_download_command_valid_magnet(monkeypatch: pytest.MonkeyPatch):
     mock_run_func = MagicMock()
-    monkeypatch.setattr("torrra.utils.indexer.run_with_default_indexer", mock_run_func)
+    monkeypatch.setattr("torrra.utils.indexer.run_without_indexer", mock_run_func)
 
     runner = CliRunner()
     magnet = "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567&dn=test"
     result = runner.invoke(cli, ["download", magnet, "--no-cache"])
 
     assert result.exit_code == 0
+    # direct download must not require an indexer
     mock_run_func.assert_called_once_with(no_cache=True, direct_download=magnet)
 
 
@@ -94,3 +95,17 @@ def test_download_command_invalid_input():
 
     assert result.exit_code == 0
     assert "Invalid input" in result.output
+
+
+def test_downloads_command_calls_runner_without_indexer(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # the downloads view must launch without an indexer configured
+    mock_run_func = MagicMock()
+    monkeypatch.setattr("torrra.utils.indexer.run_without_indexer", mock_run_func)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["downloads", "--no-cache"])
+
+    assert result.exit_code == 0
+    mock_run_func.assert_called_once_with(no_cache=True, show_downloads=True)


### PR DESCRIPTION
## Summary

Fixes #281.

Previously, `torrra` required an indexer to be configured and health-checked even when launching direct downloads (`torrra download <magnet_or_torrent_file>`) or opening the downloads management screen (`torrra downloads`). If no default indexer was configured in the config file, the CLI would fail and exit with an error.

This PR decouples indexer configuration checks from downloads-only entry points so that users can use `torrra` as a standalone torrent downloader without needing Jackett or Prowlarr configured.

### Key Changes:
- **Decouple indexer initialization**:
  - Added `run_without_indexer()` in `torrra.utils.indexer` which initializes `TorrraApp` with `indexer=None`.
  - Routed `torrra download` and `torrra downloads` CLI commands to `run_without_indexer`.
  - Preserved requirement of default indexer for search-related entry points (`torrra` and `torrra search <query>`).
- **Downloads-Only UI Mode**:
  - `TorrraApp` and `HomeScreen` accept optional `indexer: Indexer | None`.
  - When `indexer` is `None`, `WelcomeScreen` and `SearchContent` are bypassed and excluded from the view switcher.
  - `Sidebar` hides the `Search` menu entry when `show_search=False`, defaulting selection and focus to `Downloads`.
- **Tests**:
  - Added test suite in `tests/screens/test_downloads_only.py` to ensure downloads and direct download entry points launch and interact cleanly without an indexer.
  - Updated CLI command tests in `tests/test_cli.py`.
