### PR TITLE
refactor: remove transmission daemon support

### DIFF
--- a/src/torrra/core/config.py
+++ b/src/torrra/core/config.py
@@ -131,9 +131,6 @@ class Config:
             "general": {
                 "download_path": user_downloads_dir(),
                 "download_in_external_client": False,
-                "use_transmission": False,
-                "transmission_user": "",
-                "transmission_pass": "",
                 "theme": "textual-dark",
                 "timeout": DEFAULT_TIMEOUT,
                 "max_retries": DEFAULT_MAX_RETRIES,

--- a/src/torrra/widgets/search.py
+++ b/src/torrra/widgets/search.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import asyncio
-import subprocess
 from typing import Any, ClassVar, cast
 
 import httpx
@@ -196,33 +194,11 @@ class SearchContent(Vertical):
         config = get_config()
         if config.get("general.download_in_external_client", False):
             self._is_selecting_files = False
-            if config.get("general.use_transmission", False):
-                tran_user = config.get("general.transmission_user", "")
-                tran_pass = config.get("general.transmission_pass", "")
-
-                await asyncio.to_thread(
-                    subprocess.run,
-                    [
-                        "transmission-remote",
-                        "--auth",
-                        f"{tran_user}:{tran_pass}",
-                        "-a",
-                        resolved_magnet_uri,
-                    ],
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-                self.notify(
-                    "Opened in [b]transmission-remote[/b]",
-                    title="Torrent Opened",
-                )
-            else:
-                self.app.open_url(resolved_magnet_uri)
-                self.notify(
-                    "Opened in default magnet: handler",
-                    title="Torrent Opened",
-                )
+            self.app.open_url(resolved_magnet_uri)
+            self.notify(
+                "Opened in default magnet: handler",
+                title="Torrent Opened",
+            )
         else:  # continue with libtorrent file selection
             self.app.push_screen(
                 FileSelectionScreen(


### PR DESCRIPTION
## Summary
Removes the `transmission-remote` daemon logic and its associated configuration options (`use_transmission`, `transmission_user`, `transmission_pass`).

## Motivation & Context
- **Redundancy:** We already have the `download_in_external_client` option, which delegates magnet links directly to the user's default torrent client handler via `open_url`.
- **Codebase Simplification:** Hardcoding `transmission-remote` subprocess calls introduced unnecessary coupling, credentials handling, and assumptions about local/remote daemon setups without providing a complete client management solution.
- **Future Improvements:** Removing this specific daemon implementation keeps the current download pathways clean and focused (in-app `libtorrent` downloader vs. external client) while paving the way for a more modular download manager integration down the road.

## Changes
- **`src/torrra/core/config.py`**: Removed `use_transmission`, `transmission_user`, and `transmission_pass` from default configuration options.
- **`src/torrra/widgets/search.py`**: Removed `transmission-remote` subprocess execution and unused imports (`subprocess`, `asyncio`). Simplified `download_in_external_client` to directly invoke `self.app.open_url(resolved_magnet_uri)`.
