### PR TITLE
feat: add ARM64 support for Docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ vars.DOCKERHUB_USERNAME }}/torrra:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY src ./src
 RUN uv pip install --system --no-cache-dir -r requirements.txt
 
 # stage 2: final image
-FROM python:3.13-alpine
+FROM python:3.13-slim
 
 WORKDIR /app
 
@@ -26,13 +26,13 @@ ENV PYTHONUNBUFFERED=1
 ENV PIP_ROOT_USER_ACTION=ignore
 
 # create a non-root user and group
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+RUN useradd -m -u 1000 appuser
 
 # copy installed packages from the builder stage
 COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 
 # copy the application source and executable
-COPY --from=builder --chown=appuser:appgroup /app/src ./src
+COPY --from=builder --chown=appuser:appuser /app/src ./src
 COPY --from=builder /usr/local/bin/torrra /usr/local/bin/torrra
 
 # switch to the non-root user


### PR DESCRIPTION
## Summary
- Adds multi-architecture support (`linux/amd64`, `linux/arm64`) to the Docker publish step in the release workflow.
- Standardizes the runtime stage in `Dockerfile` to `python:3.13-slim` (matching the builder stage) to ensure binary compatibility (glibc) for native dependencies like `libtorrent`.
- Updates user creation in `Dockerfile` to use `useradd` for Debian-based slim images.

## Related Issues
Closes #286