### PR TITLE
feat: add PowerShell installer script and WinGet support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,3 +153,14 @@ jobs:
           pkgver: ${{ steps.version.outputs.version }}
           pkgbuild_template: ./pkgbuild-template/torrra-bin/PKGBUILD
           aur_ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+
+  winget:
+    name: Publish to WinGet
+    needs: build_and_attach_bin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish to Windows Package Manager Repository
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: stabldev.torrra
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,7 @@ jobs:
     name: Publish to WinGet
     needs: build_and_attach_bin
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Publish to Windows Package Manager Repository
         uses: vedantmgoyal2009/winget-releaser@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,7 @@ jobs:
     permissions: {}
     steps:
       - name: Publish to Windows Package Manager Repository
-        uses: vedantmgoyal2009/winget-releaser@v2
+        uses: vedantmgoyal2009/winget-releaser@main
         with:
           identifier: stabldev.torrra
           token: ${{ secrets.WINGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ uv tool install torrra
 # or pipx install torrra
 ```
 
-Other options: [`AUR`](https://aur.archlinux.org/packages/torrra), [`standalone binaries`](https://github.com/stabldev/torrra/releases), [`Homebrew`](https://github.com/Maniacsan/homebrew-torrra) or [`Docker`](https://hub.docker.com/r/stabldev/torrra).
+Other options: [`WinGet`](https://torrra.readthedocs.io/en/latest/installation.html#windows), [`AUR`](https://aur.archlinux.org/packages/torrra), [`Homebrew`](https://github.com/Maniacsan/homebrew-torrra), [`standalone binaries`](https://github.com/stabldev/torrra/releases), or [`Docker`](https://hub.docker.com/r/stabldev/torrra).
 
 [See full install options →](https://torrra.readthedocs.io/en/latest/installation.html)
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@
 ![demo](./docs/assets/demo.gif)
 
 _Torrra_ provides a streamlined command-line interface for torrent search and downloads, powered by Jackett/Prowlarr and Libtorrent. Built with Textual, it offers a beautiful
-TUI with pause/resume support - all without leaving your terminal.
-
-**Full documentation**: https://torrra.readthedocs.io/en/latest/
+TUI with pause/resume support. https://torrra.readthedocs.io/en/latest/
 
 ## Installation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,6 +71,24 @@ You can download pre-built executables of `torrra` directly from the [GitHub Rel
 >
 > (Replace `vX.Y.Z-*-x86_64` with the actual filename you downloaded.)
 
+## Windows
+
+On Windows, you can install `torrra` directly without needing Python or `uv`:
+
+### Via WinGet (Recommended)
+
+```powershell
+winget install stabldev.torrra
+```
+
+### Via PowerShell Installer Script
+
+Run in PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/stabldev/torrra/main/install.ps1 | iex
+```
+
 ## Homebrew (macOS)
 
 Thanks to community contribution, `torrra` is also available via [Homebrew](https://brew.sh/) for macOS users.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,47 @@
+#Requires -Version 5.1
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+if (-not [Environment]::Is64BitOperatingSystem) {
+  throw "torrra standalone binary requires 64-bit Windows."
+}
+
+$repo = "stabldev/torrra"
+$binDir = Join-Path $env:LOCALAPPDATA "torrra\bin"
+$exe = Join-Path $binDir "torrra.exe"
+
+try {
+  $release = Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest" -Headers @{ "User-Agent" = "torrra-installer" } -UseBasicParsing
+  $url = ($release.assets | Where-Object name -like "*windows*.exe" | Select-Object -First 1).browser_download_url
+  $version = $release.tag_name
+}
+catch {
+  $req = [System.Net.WebRequest]::Create("https://github.com/$repo/releases/latest")
+  $req.AllowAutoRedirect = $false
+  $resp = $req.GetResponse()
+  $version = $resp.GetResponseHeader("Location").Split('/')[-1]
+  $resp.Close()
+  $url = "https://github.com/$repo/releases/download/$version/torrra_${version}_windows_x86_64.exe"
+}
+
+if (-not $url) {
+  throw "Failed to resolve download URL for torrra."
+}
+
+New-Item -ItemType Directory -Force -Path $binDir | Out-Null
+Invoke-WebRequest -Uri $url -OutFile $exe -UseBasicParsing
+
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if (($userPath -split ';') -replace '\\$' -notcontains $binDir) {
+  [Environment]::SetEnvironmentVariable("Path", ($userPath, $binDir -join ';').Trim(';'), "User")
+}
+
+if (($env:Path -split ';') -replace '\\$' -notcontains $binDir) {
+  $env:Path = "$binDir;$env:Path"
+}
+
+Write-Host "`ntorrra $version installed successfully!" -ForegroundColor Green
+Write-Host "Location: $exe" -ForegroundColor DarkGray
+Write-Host "Run: torrra --help" -ForegroundColor Yellow

--- a/install.ps1
+++ b/install.ps1
@@ -12,6 +12,8 @@ $repo = "stabldev/torrra"
 $binDir = Join-Path $env:LOCALAPPDATA "torrra\bin"
 $exe = Join-Path $binDir "torrra.exe"
 
+Write-Host "Installing torrra..."
+
 try {
   $release = Invoke-RestMethod "https://api.github.com/repos/$repo/releases/latest" -Headers @{ "User-Agent" = "torrra-installer" } -UseBasicParsing
   $url = ($release.assets | Where-Object name -like "*windows*.exe" | Select-Object -First 1).browser_download_url
@@ -42,6 +44,6 @@ if (($env:Path -split ';') -replace '\\$' -notcontains $binDir) {
   $env:Path = "$binDir;$env:Path"
 }
 
-Write-Host "`ntorrra $version installed successfully!" -ForegroundColor Green
-Write-Host "Location: $exe" -ForegroundColor DarkGray
-Write-Host "Run: torrra --help" -ForegroundColor Yellow
+Write-Host "`ntorrra $version installed successfully!"
+Write-Host "Location: $exe"
+Write-Host "Run: torrra --help"


### PR DESCRIPTION
## Summary

- Adds a minimal, standalone Windows PowerShell installer script (`install.ps1`) for downloading the latest release binary and configuring user/session `PATH`.
- Adds a WinGet release job in GitHub Actions release workflow (`.github/workflows/release.yml`).
- Updates installation documentation and README with Windows installation instructions.

## Changes
- `install.ps1`: Streamlined script supporting PowerShell 5.1 and pwsh 7+, handles TLS 1.2+, release discovery with GitHub API / tag redirect fallback, and PATH configuration.
- `.github/workflows/release.yml`: Added `winget` publishing job using `vedantmgoyal2009/winget-releaser`.
- `docs/installation.md` & `README.md`: Added Windows installation sections.
