### PR TITLE
feat: add edit subcommand to config command

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,7 +100,7 @@ If the selected indexer is not defined in the config file, `torrra` will show an
 
 `torrra` provides built-in command-line tools to inspect and modify your configuration settings without directly editing the `config.toml` file. This is particularly useful for scripting or quick adjustments.
 
-Use the `torrra config` subcommand followed by `get`, `set`, or `list`.
+Use the `torrra config` subcommand followed by `get`, `set`, `list`, or `edit`.
 
 ### Retrieving a Configuration Value
 
@@ -131,3 +131,18 @@ torrra config list
 ```
 
 This command will display a comprehensive list of all configured settings and their current values, including general preferences and indexer-related entries.
+
+### Editing Configuration in an Editor
+
+To open the `config.toml` file directly in your default command-line editor (or the editor set in `$VISUAL` / `$EDITOR`):
+
+```bash
+torrra config edit
+```
+
+You can also specify a custom editor using the `--editor` (or `-e`) option:
+
+```bash
+torrra config edit --editor nano
+```
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,6 +82,7 @@ These subcommands allow you to manage `torrra`'s configuration directly from the
 | `torrra config get <key>`         | Retrieves the value associated with a specific configuration key |
 | `torrra config set <key> <value>` | Sets a configuration key to a specified value                    |
 | `torrra config list`              | Lists all currently set configuration values                     |
+| `torrra config edit`              | Opens the configuration file in the default editor               |
 
 ### Indexer Options
 

--- a/src/torrra/__main__.py
+++ b/src/torrra/__main__.py
@@ -182,11 +182,7 @@ def config_edit(editor: str | None = None):
         with open(CONFIG_FILE, "rb") as f:
             tomllib.load(f)
     except (OSError, tomllib.TOMLDecodeError) as e:
-        click.secho(
-            f"Warning: Configuration file contains invalid TOML: {e}",
-            fg="yellow",
-            err=True,
-        )
+        click.secho(f"Invalid Configuration: {e}", fg="yellow", err=True)
 
 
 if __name__ == "__main__":

--- a/src/torrra/__main__.py
+++ b/src/torrra/__main__.py
@@ -191,4 +191,3 @@ def config_edit(editor: str | None = None):
 
 if __name__ == "__main__":
     cli()
-

--- a/src/torrra/__main__.py
+++ b/src/torrra/__main__.py
@@ -152,5 +152,43 @@ def config_list():
         click.secho(e, fg="red", err=True)
 
 
+@config.command(name="edit", help="Open the configuration file in the default editor.")
+@click.option(
+    "-e",
+    "--editor",
+    required=False,
+    help="Editor command to use (defaults to $VISUAL, $EDITOR, or system default).",
+)
+def config_edit(editor: str | None = None):
+    from torrra.core.config import CONFIG_FILE, get_config
+    from torrra.utils.helpers import get_tomllib
+
+    tomllib = get_tomllib()
+
+    # Ensure config file exists before editing
+    get_config()
+
+    try:
+        click.edit(filename=str(CONFIG_FILE), editor=editor)
+    except (click.ClickException, OSError) as e:
+        click.secho(f"Failed to open editor: {e}", fg="red", err=True)
+        return
+
+    # Clear cached config instance so subsequent calls reload changes
+    get_config.cache_clear()
+
+    # Validate TOML syntax after editing
+    try:
+        with open(CONFIG_FILE, "rb") as f:
+            tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError) as e:
+        click.secho(
+            f"Warning: Configuration file contains invalid TOML: {e}",
+            fg="yellow",
+            err=True,
+        )
+
+
 if __name__ == "__main__":
     cli()
+

--- a/src/torrra/core/config.py
+++ b/src/torrra/core/config.py
@@ -1,5 +1,4 @@
 import ast
-import sys
 from contextlib import suppress
 from functools import lru_cache
 from pathlib import Path
@@ -17,11 +16,7 @@ from torrra.core.constants import (
     DEFAULT_TIMEOUT,
 )
 from torrra.core.exceptions import ConfigError
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:  # Python <3.11
-    import tomli as tomllib  # type: ignore
+from torrra.utils.helpers import get_tomllib
 
 CONFIG_DIR = Path(user_config_dir("torrra"))
 CONFIG_FILE = CONFIG_DIR / "config.toml"
@@ -120,6 +115,7 @@ class Config:
             self._create_default_config()
             self._save_config()
 
+        tomllib = get_tomllib()
         try:
             with open(CONFIG_FILE, "rb") as f:
                 self.config = tomllib.load(f)

--- a/src/torrra/utils/helpers.py
+++ b/src/torrra/utils/helpers.py
@@ -65,4 +65,3 @@ def get_tomllib():
         import tomli as tomllib  # type: ignore
 
     return tomllib
-

--- a/src/torrra/utils/helpers.py
+++ b/src/torrra/utils/helpers.py
@@ -54,3 +54,15 @@ def lazy_import(dotted_path: str):
         return getattr(module, obj_name)
     except (ModuleNotFoundError, AttributeError) as e:
         raise ImportError(f"failed to import: {dotted_path}\n{e}")
+
+
+def get_tomllib():
+    import sys
+
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:  # Python <3.11
+        import tomli as tomllib  # type: ignore
+
+    return tomllib
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -149,7 +149,7 @@ def test_config_edit_invalid_toml_warning(
     result = runner.invoke(cli, ["config", "edit"])
 
     assert result.exit_code == 0
-    assert "Warning: Configuration file contains invalid TOML" in result.output
+    assert "Invalid Configuration" in result.output
 
 
 def test_config_edit_error_handling(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -5,6 +6,7 @@ from click.testing import CliRunner
 
 from torrra.__main__ import cli
 from torrra._version import __version__
+from torrra.core.config import Config
 
 
 def test_cli_version():
@@ -74,6 +76,124 @@ def test_config_commands_flow():
     list_result = runner.invoke(cli, ["config", "list"])
     assert list_result.exit_code == 0
     assert "test.key=test_value" in list_result.output
+
+
+def test_config_edit_opens_editor(monkeypatch: pytest.MonkeyPatch, mock_config: Config):
+    from torrra.core import config as config_module
+
+    mock_edit = MagicMock()
+    monkeypatch.setattr("click.edit", mock_edit)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "edit"])
+
+    assert result.exit_code == 0
+    mock_edit.assert_called_once_with(
+        filename=str(config_module.CONFIG_FILE), editor=None
+    )
+
+
+def test_config_edit_with_custom_editor(
+    monkeypatch: pytest.MonkeyPatch, mock_config: Config
+):
+    from torrra.core import config as config_module
+
+    mock_edit = MagicMock()
+    monkeypatch.setattr("click.edit", mock_edit)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "edit", "--editor", "nano"])
+
+    assert result.exit_code == 0
+    mock_edit.assert_called_once_with(
+        filename=str(config_module.CONFIG_FILE), editor="nano"
+    )
+
+    # test short option -e
+    mock_edit.reset_mock()
+    result_short = runner.invoke(cli, ["config", "edit", "-e", "vim"])
+    assert result_short.exit_code == 0
+    mock_edit.assert_called_once_with(
+        filename=str(config_module.CONFIG_FILE), editor="vim"
+    )
+
+
+def test_config_edit_updates_cache(
+    monkeypatch: pytest.MonkeyPatch, mock_config: Config
+):
+    from torrra.core.config import get_config
+
+    def mock_edit_write(filename: str, editor: str | None = None):
+        with open(filename, "w", encoding="utf-8") as f:
+            f.write('[general]\ntheme = "custom-theme"\n')
+
+    monkeypatch.setattr("click.edit", mock_edit_write)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "edit"])
+
+    assert result.exit_code == 0
+    assert get_config().get("general.theme") == "custom-theme"
+
+
+def test_config_edit_invalid_toml_warning(
+    monkeypatch: pytest.MonkeyPatch, mock_config: Config
+):
+    def mock_edit_invalid(filename: str, editor: str | None = None):
+        with open(filename, "w", encoding="utf-8") as f:
+            f.write("invalid toml syntax = = =\n")
+
+    monkeypatch.setattr("click.edit", mock_edit_invalid)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "edit"])
+
+    assert result.exit_code == 0
+    assert "Warning: Configuration file contains invalid TOML" in result.output
+
+
+def test_config_edit_error_handling(
+    monkeypatch: pytest.MonkeyPatch, mock_config: Config
+):
+    import click
+
+    def mock_edit_fail(filename: str, editor: str | None = None):
+        raise click.ClickException("Editor not found")
+
+    monkeypatch.setattr("click.edit", mock_edit_fail)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "edit"])
+
+    assert result.exit_code == 0
+    assert "Failed to open editor: Editor not found" in result.output
+
+
+def test_config_edit_creates_default_file_if_not_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from torrra.core import config as config_module
+
+    temp_config_dir = tmp_path / "new_torrra"
+    temp_config_file = temp_config_dir / "config.toml"
+    monkeypatch.setattr(config_module, "CONFIG_DIR", temp_config_dir)
+    monkeypatch.setattr(config_module, "CONFIG_FILE", temp_config_file)
+    config_module.get_config.cache_clear()
+
+    assert not temp_config_file.exists()
+
+    mock_edit = MagicMock()
+    monkeypatch.setattr("click.edit", mock_edit)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["config", "edit"])
+
+    assert result.exit_code == 0
+    assert temp_config_file.exists()
+    mock_edit.assert_called_once_with(
+        filename=str(temp_config_file), editor=None
+    )
+    config_module.get_config.cache_clear()
 
 
 def test_download_command_valid_magnet(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -190,9 +190,7 @@ def test_config_edit_creates_default_file_if_not_exists(
 
     assert result.exit_code == 0
     assert temp_config_file.exists()
-    mock_edit.assert_called_once_with(
-        filename=str(temp_config_file), editor=None
-    )
+    mock_edit.assert_called_once_with(filename=str(temp_config_file), editor=None)
     config_module.get_config.cache_clear()
 
 

--- a/tests/test_utils_helpers.py
+++ b/tests/test_utils_helpers.py
@@ -51,4 +51,3 @@ def test_get_tomllib():
     assert hasattr(tomllib, "TOMLDecodeError")
     parsed = tomllib.loads('key = "value"')
     assert parsed == {"key": "value"}
-

--- a/tests/test_utils_helpers.py
+++ b/tests/test_utils_helpers.py
@@ -1,6 +1,11 @@
 import pytest
 
-from torrra.utils.helpers import human_readable_eta, human_readable_size, lazy_import
+from torrra.utils.helpers import (
+    get_tomllib,
+    human_readable_eta,
+    human_readable_size,
+    lazy_import,
+)
 
 
 def test_human_readable_size():
@@ -37,3 +42,13 @@ def test_lazy_import_failure():
 
     assert "nonexistent_mod.func" in str(exc.value)
     assert "No module named" in str(exc.value)
+
+
+def test_get_tomllib():
+    tomllib = get_tomllib()
+    assert hasattr(tomllib, "load")
+    assert hasattr(tomllib, "loads")
+    assert hasattr(tomllib, "TOMLDecodeError")
+    parsed = tomllib.loads('key = "value"')
+    assert parsed == {"key": "value"}
+


### PR DESCRIPTION
## Summary
- Adds `torrra config edit` subcommand to open the configuration file in the user's default command-line editor (detected via `$VISUAL`, `$EDITOR`, or system default editor).
- Adds `-e` / `--editor` options to allow specifying a custom editor command.
- Ensures the default `config.toml` file is created before launching the editor if it doesn't exist yet.
- Clears the `get_config()` LRU cache after editing so updated configuration is immediately available in-process.
- Validates TOML syntax upon exiting the editor and warns if syntax errors are present.
- Introduces `get_tomllib()` helper in `torrra.utils.helpers` to unify conditional `tomllib`/`tomli` imports.
- Replaces blind exception catching with specific exception types.
- Adds unit tests in `tests/test_cli.py` and `tests/test_utils_helpers.py`.
- Updates documentation in `docs/configuration.md` and `docs/usage.md`.

## Test Plan
- Run full test suite: `uv run pytest`
- Run type checks: `uv run ty check`
- Run linter: `uv run ruff check`