### PR TITLE
refactor: remove unnecessary toast notifications

### DIFF
--- a/src/torrra/screens/theme_selector.py
+++ b/src/torrra/screens/theme_selector.py
@@ -55,10 +55,6 @@ class ThemeSelectorScreen(ModalScreen[None]):
         self._cancel_update_worker()
         if self.app.theme != self.original_theme:
             get_config().set("general.theme", self.app.theme)
-            self.notify(
-                f"Switched to [b]{self.app.theme}[/b] theme",
-                title="Theme Changed",
-            )
         self.app.pop_screen()
 
     def action_close_screen(self) -> None:

--- a/src/torrra/widgets/downloads.py
+++ b/src/torrra/widgets/downloads.py
@@ -151,8 +151,6 @@ class DownloadsContent(Vertical):
             return
 
         magnet_uri = self._selected_torrent["magnet_uri"]
-        title = self._selected_torrent["title"]
-        short_title = (title[:50] + "...") if len(title) > 40 else title
 
         status = self._dm.get_torrent_status(magnet_uri)
         if not status:
@@ -165,17 +163,6 @@ class DownloadsContent(Vertical):
 
         if self._selected_torrent:
             self._selected_torrent["is_paused"] = target_paused
-
-        if target_paused:
-            self.notify(
-                f"Paused download of [b]{short_title}[/b]",
-                title="Download Paused",
-            )
-        else:
-            self.notify(
-                f"Resumed download of [b]{short_title}[/b]",
-                title="Download Resumed",
-            )
 
     def action_delete_torrent(self) -> None:
         self._remove_selected_torrent()
@@ -219,20 +206,11 @@ class DownloadsContent(Vertical):
         self._dm.set_file_priorities(magnet_uri, priorities)
         self._tm.update_torrent_file_priorities(magnet_uri, priorities)
 
-        title = self._selected_torrent["title"]
-        short_title = (title[:50] + "...") if len(title) > 40 else title
-        self.notify(
-            f"Updated file selection for [b]{short_title}[/b]",
-            title="Files Updated",
-        )
-
     def _remove_selected_torrent(self, delete_files: bool = False) -> None:
         if not self._selected_torrent:
             return
 
         magnet_uri = self._selected_torrent["magnet_uri"]
-        title = self._selected_torrent["title"]
-        short_title = (title[:50] + "...") if len(title) > 40 else title
 
         self._dm.remove_torrent(magnet_uri, delete_files=delete_files)
         self._tm.remove_torrent(magnet_uri)
@@ -242,16 +220,6 @@ class DownloadsContent(Vertical):
         self._selected_torrent = None
         self._details_panel.add_class("hidden")
         self._filter_table()
-
-        msg = (
-            f"Removed [b]{short_title}[/b] and its data"
-            if delete_files
-            else f"Removed [b]{short_title}[/b] from list"
-        )
-        self.notify(
-            msg,
-            title="Torrent Removed",
-        )
 
     def on_details_panel_closed(self):
         self._selected_torrent = None

--- a/src/torrra/widgets/search.py
+++ b/src/torrra/widgets/search.py
@@ -227,12 +227,6 @@ class SearchContent(Vertical):
             torrent_info=getattr(self, "_current_torrent_info", None),
         )
 
-        title = self._selected_torrent.title
-        short_title = (title[:30] + "...") if len(title) > 30 else title
-        self.notify(
-            f"Started downloading [b]{short_title}[/b]",
-            title="Download Started",
-        )
         self.post_message(self.DownloadRequested(self._selected_torrent))
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
@@ -329,7 +323,7 @@ class SearchContent(Vertical):
         # are declared with once a search returns a few hundred results
         self._table.fit_columns()
 
-    def _refresh_view(self, message: str) -> None:
+    def _refresh_view(self) -> None:
         """Re-render after a sort/filter change, unless nothing is loaded yet."""
         if not self._view.total:
             return
@@ -337,7 +331,6 @@ class SearchContent(Vertical):
         self._selected_torrent = None
         self._render_rows()
         self._table.focus()
-        self.notify(message, title="Results Updated")
 
     def action_open_sort_menu(self) -> None:
         if not self._view.total:
@@ -350,32 +343,23 @@ class SearchContent(Vertical):
         if key is None:  # cancelled
             return
         self._view.set_sort(key)
-        self._refresh_view(f"Sorted by [b]{self._view.sort_label}[/b]")
+        self._refresh_view()
 
     def action_toggle_sort_order(self) -> None:
         self._view.toggle_direction()
-        self._refresh_view(f"Sorted by [b]{self._view.sort_label}[/b]")
+        self._refresh_view()
 
     def action_toggle_seeded_only(self) -> None:
         filters = self._view.filters
         filters.min_seeders = 0 if filters.min_seeders else 1
-        self._refresh_view(
-            "Hiding results with [b]0 seeders[/b]"
-            if filters.min_seeders
-            else "Showing [b]all[/b] results"
-        )
+        self._refresh_view()
 
     def action_clear_filters(self) -> None:
         # back to the configured baseline rather than hardcoded relevance, so a
         # configured default_sort stays reachable instead of being startup-only
         sort_key, descending, min_seeders = self._config_defaults()
         self._view.reset_to(sort_key, descending, min_seeders)
-
-        message = f"Reset to [b]{self._view.sort_label}[/b]"
-        if min_seeders:
-            plural = "" if min_seeders == 1 else "s"
-            message += f", hiding under [b]{min_seeders}[/b] seeder{plural}"
-        self._refresh_view(message)
+        self._refresh_view()
 
     @on(AutoResizingDataTable.HeaderSelected)
     def on_header_selected(self, event: AutoResizingDataTable.HeaderSelected) -> None:
@@ -391,7 +375,7 @@ class SearchContent(Vertical):
         else:
             self._view.set_sort(key)
 
-        self._refresh_view(f"Sorted by [b]{self._view.sort_label}[/b]")
+        self._refresh_view()
 
     def _get_indexer_instance(self) -> BaseIndexer:
         if self._indexer_instance_cache:


### PR DESCRIPTION
## Description
This PR removes redundant and frequent toast notifications across the TUI workflow to reduce visual noise and improve the user experience.

### Summary of Changes
- **Search View**:
  - Removed Results Updated toasts on sort/filter actions (the results table and border title already provide instant visual feedback).
  - Removed Download Started toast when starting a download from search (the UI automatically switches focus to the Downloads view).
- **Downloads View**:
  - Removed Download Paused / Download Resumed toasts on \p\ toggle (status column updates immediately).
  - Removed Files Updated toast after closing the file selection modal.
  - Removed Torrent Removed toast on deletion (the row is removed from the table immediately).
- **Theme Selector**:
  - Removed Theme Changed toast on selection (theme applies in real time).

### Preserved Critical Notifications
- Background download completion notification (\Download Finished\).
- Input validation warning in file selection (\No Files Selected\).
- Error notifications (search failure, failed URI resolution).
- External client launch confirmation (\Opened in default magnet: handler\).

## Testing
- Ran full test suite (\pytest\): 206 passed.