### PR TITLE
fix: expand and resolve download_path in config

### DIFF
--- a/src/torrra/app.py
+++ b/src/torrra/app.py
@@ -10,6 +10,7 @@ from typing_extensions import override
 
 from torrra._types import Indexer
 from torrra.core.config import get_config
+from torrra.core.exceptions import ConfigError
 from torrra.screens.help import HelpScreen
 from torrra.screens.home import HomeScreen
 from torrra.screens.theme_selector import ThemeSelectorScreen
@@ -51,6 +52,14 @@ class TorrraApp(App[None]):
                 + f"available themes: {', '.join(sorted(self.available_themes))}"
             )
         self.theme = theme
+
+        # validate the download path up front so a bad value is reported once,
+        # here, instead of surfacing as an uncaught error (or a silently
+        # skipped torrent) every time a download is added
+        try:
+            get_config().get("general.download_path")
+        except ConfigError as e:
+            raise RuntimeError(f"invalid download_path configured.\n{e}") from e
 
     async def on_mount(self) -> None:
         # the welcome screen only exists to collect a search query, so it is

--- a/src/torrra/core/config.py
+++ b/src/torrra/core/config.py
@@ -35,7 +35,10 @@ def _resolve_path(value: str) -> str:
     # an unresolved variable is only harmful because it leaves the path
     # relative, which anchors it to the cwd; a literal '$' in an absolute
     # path is a valid filename character and must be left alone
-    if not (os.path.isabs(resolved) or resolved.startswith(("/", "\\"))) and "$" in expanded:
+    if (
+        not (os.path.isabs(resolved) or resolved.startswith(("/", "\\")))
+        and "$" in expanded
+    ):
         raise ConfigError(f"unresolved environment variable in path: {value}")
     return os.path.abspath(resolved)
 

--- a/src/torrra/core/config.py
+++ b/src/torrra/core/config.py
@@ -1,6 +1,7 @@
 import ast
 from contextlib import suppress
 from functools import lru_cache
+import os
 from pathlib import Path
 from typing import Any, cast
 
@@ -48,10 +49,18 @@ class Config:
                 raise ConfigError(
                     f"key does not contain a value (it's a section): {key_path}"
                 )
+
+            if key_path == "general.download_path" and isinstance(current, str):
+                return os.path.abspath(os.path.expanduser(os.path.expandvars(current)))
+
             return current
 
         except (KeyError, TypeError):
             if default is not _sentinel:
+                if key_path == "general.download_path" and isinstance(default, str):
+                    return os.path.abspath(
+                        os.path.expanduser(os.path.expandvars(default))
+                    )
                 return default
 
             if len(keys) > 1:

--- a/src/torrra/core/config.py
+++ b/src/torrra/core/config.py
@@ -26,6 +26,15 @@ CONFIG_FILE = CONFIG_DIR / "config.toml"
 # config.get(..., default=...) value check
 _sentinel = object()
 
+_PATH_KEYS = {"general.download_path"}
+
+
+def _resolve_path(value: str) -> str:
+    expanded = os.path.expandvars(value)
+    if "$" in expanded:
+        raise ConfigError(f"unresolved environment variable in path: {value}")
+    return os.path.abspath(os.path.expanduser(expanded))
+
 
 @lru_cache
 def get_config() -> "Config":
@@ -50,17 +59,15 @@ class Config:
                     f"key does not contain a value (it's a section): {key_path}"
                 )
 
-            if key_path == "general.download_path" and isinstance(current, str):
-                return os.path.abspath(os.path.expanduser(os.path.expandvars(current)))
+            if key_path in _PATH_KEYS and isinstance(current, str):
+                return _resolve_path(current)
 
             return current
 
         except (KeyError, TypeError):
             if default is not _sentinel:
-                if key_path == "general.download_path" and isinstance(default, str):
-                    return os.path.abspath(
-                        os.path.expanduser(os.path.expandvars(default))
-                    )
+                if key_path in _PATH_KEYS and isinstance(default, str):
+                    return _resolve_path(default)
                 return default
 
             if len(keys) > 1:

--- a/src/torrra/core/config.py
+++ b/src/torrra/core/config.py
@@ -1,7 +1,7 @@
 import ast
+import os
 from contextlib import suppress
 from functools import lru_cache
-import os
 from pathlib import Path
 from typing import Any, cast
 

--- a/src/torrra/core/config.py
+++ b/src/torrra/core/config.py
@@ -31,9 +31,13 @@ _PATH_KEYS = {"general.download_path"}
 
 def _resolve_path(value: str) -> str:
     expanded = os.path.expandvars(value)
-    if "$" in expanded:
+    resolved = os.path.expanduser(expanded)
+    # an unresolved variable is only harmful because it leaves the path
+    # relative, which anchors it to the cwd; a literal '$' in an absolute
+    # path is a valid filename character and must be left alone
+    if not (os.path.isabs(resolved) or resolved.startswith(("/", "\\"))) and "$" in expanded:
         raise ConfigError(f"unresolved environment variable in path: {value}")
-    return os.path.abspath(os.path.expanduser(expanded))
+    return os.path.abspath(resolved)
 
 
 @lru_cache

--- a/src/torrra/core/download.py
+++ b/src/torrra/core/download.py
@@ -245,6 +245,9 @@ class DownloadManager:
                 if info:
                     save_path = s.save_path or get_config().get("general.download_path")
                     if save_path:
+                        save_path = os.path.abspath(
+                            os.path.expanduser(os.path.expandvars(save_path))
+                        )
                         fs = info.files()
                         priorities = self.get_file_priorities(magnet_uri)
                         for i in range(fs.num_files()):

--- a/tests/screens/test_downloads_only.py
+++ b/tests/screens/test_downloads_only.py
@@ -1,3 +1,4 @@
+import pytest
 from textual.widgets import ContentSwitcher
 
 from torrra.app import TorrraApp
@@ -90,3 +91,33 @@ async def test_downloads_content_is_interactive_without_indexer():
 
         downloads = app.screen.query_one(DownloadsContent)
         assert downloads._table.has_focus
+
+
+def test_app_rejects_invalid_download_path_at_startup(mock_config):
+    # a download_path that cannot resolve must be reported once at startup,
+    # not surface as an uncaught error when a torrent is later added
+    mock_config.set("general.download_path", "$UNDEFINED_VAR_STARTUP/downloads")
+
+    with pytest.raises(RuntimeError, match="invalid download_path configured"):
+        TorrraApp(
+            indexer=None,
+            use_cache=False,
+            search_query=None,
+            show_downloads=True,
+        )
+
+
+def test_app_accepts_literal_dollar_in_download_path(mock_config):
+    # regression: '$' is a legal filename character in an absolute path
+    mock_config.set("general.download_path", "/Volumes/My$Drive/Downloads")
+
+    # constructing the app is enough - validation happens in __init__, and
+    # running the TUI here would touch the real torrent database
+    app = TorrraApp(
+        indexer=None,
+        use_cache=False,
+        search_query=None,
+        show_downloads=True,
+    )
+
+    assert app.show_downloads is True

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 import pytest
 
 from torrra.core import config as config_module
@@ -107,9 +110,31 @@ def test_config_get_download_path_default_expansion(mock_config: Config):
     assert result == expected
 
 
-def test_config_get_download_path_undefined_env_var_raises_error(
+def test_config_get_download_path_allows_literal_dollar_in_absolute_path(
+    mock_config: Config,
+):
+    # '$' is a legal filename character; an absolute path containing one is
+    # valid and must not be mistaken for an unresolved environment variable
+    test_path = "/Volumes/My$Drive/Downloads"
+    mock_config.set("general.download_path", test_path)
+    assert mock_config.get("general.download_path") == os.path.abspath(test_path)
+
+
+def test_config_get_download_path_allows_literal_dollar_after_tilde(
+    mock_config: Config, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    mock_config.set("general.download_path", "~/Music/AC$DC")
+    expected = os.path.join(str(tmp_path), "Music", "AC$DC")
+    assert mock_config.get("general.download_path") == expected
+
+
+def test_config_get_download_path_relative_with_dollar_raises_error(
     mock_config: Config, monkeypatch: pytest.MonkeyPatch
 ):
+    # a '$' that leaves the path relative is what anchors it to the cwd,
+    # which is the failure mode this validation exists to catch
     monkeypatch.delenv("UNDEFINED_VAR_TEST", raising=False)
     mock_config.set("general.download_path", "$UNDEFINED_VAR_TEST/downloads")
     with pytest.raises(ConfigError, match="unresolved environment variable"):

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -67,3 +67,42 @@ def test_config_list_flattens_correctly(mock_config: Config):
     assert "new.section.bool=true" in config_list
     # check a default value is also present
     assert "general.download_in_external_client=false" in config_list
+
+
+def test_config_get_download_path_expands_tilde(mock_config: Config):
+    import os
+
+    mock_config.set("general.download_path", "~/my_downloads")
+    expected = os.path.abspath(os.path.expanduser("~/my_downloads"))
+    assert mock_config.get("general.download_path") == expected
+
+
+def test_config_get_download_path_expands_env_vars(
+    mock_config: Config, monkeypatch: pytest.MonkeyPatch
+):
+    import os
+
+    monkeypatch.setenv("TEST_DOWNLOAD_DIR", "custom_downloads")
+    mock_config.set("general.download_path", "~/$TEST_DOWNLOAD_DIR")
+    expected = os.path.abspath(
+        os.path.expanduser(os.path.expandvars("~/$TEST_DOWNLOAD_DIR"))
+    )
+    assert mock_config.get("general.download_path") == expected
+
+
+def test_config_get_download_path_relative_to_absolute(mock_config: Config):
+    import os
+
+    mock_config.set("general.download_path", "some_relative_path")
+    expected = os.path.abspath("some_relative_path")
+    assert mock_config.get("general.download_path") == expected
+
+
+def test_config_get_download_path_default_expansion(mock_config: Config):
+    import os
+
+    del mock_config.config["general"]["download_path"]
+    result = mock_config.get("general.download_path", "~/fallback_downloads")
+    expected = os.path.abspath(os.path.expanduser("~/fallback_downloads"))
+    assert result == expected
+

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -105,4 +105,3 @@ def test_config_get_download_path_default_expansion(mock_config: Config):
     result = mock_config.get("general.download_path", "~/fallback_downloads")
     expected = os.path.abspath(os.path.expanduser("~/fallback_downloads"))
     assert result == expected
-

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -105,3 +105,17 @@ def test_config_get_download_path_default_expansion(mock_config: Config):
     result = mock_config.get("general.download_path", "~/fallback_downloads")
     expected = os.path.abspath(os.path.expanduser("~/fallback_downloads"))
     assert result == expected
+
+
+def test_config_get_download_path_undefined_env_var_raises_error(
+    mock_config: Config, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delenv("UNDEFINED_VAR_TEST", raising=False)
+    mock_config.set("general.download_path", "$UNDEFINED_VAR_TEST/downloads")
+    with pytest.raises(ConfigError, match="unresolved environment variable"):
+        mock_config.get("general.download_path")
+
+
+def test_config_get_non_path_key_not_expanded(mock_config: Config):
+    mock_config.set("general.theme", "~/not-a-path")
+    assert mock_config.get("general.theme") == "~/not-a-path"

--- a/tests/test_core_download.py
+++ b/tests/test_core_download.py
@@ -1,4 +1,7 @@
+from typing import Any
+
 import libtorrent as lt
+import pytest
 
 from torrra._types import TorrentStatus
 from torrra.core.download import DownloadManager
@@ -308,3 +311,79 @@ def test_state_map_abi2():
         lt.torrent_status.states.checking_resume_data,
     }
     assert set(DownloadManager._STATE_MAP.keys()) == expected_states
+
+
+def test_add_torrent_save_path_expanded(
+    monkeypatch: pytest.MonkeyPatch, mock_config: Any
+):
+    import os
+    from unittest.mock import MagicMock
+
+    mock_config.set("general.download_path", "~/custom_dl_path")
+    dm = DownloadManager()
+    captured_atp = []
+
+    def mock_add_torrent(atp: Any):
+        captured_atp.append(atp)
+        handle = MagicMock()
+        handle.is_valid.return_value = True
+        handle.status.return_value.has_metadata = False
+        return handle
+
+    monkeypatch.setattr(dm.session, "add_torrent", mock_add_torrent)
+    dm.add_torrent("magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567")
+
+    assert len(captured_atp) == 1
+    expected = os.path.abspath(os.path.expanduser("~/custom_dl_path"))
+    assert captured_atp[0].save_path == expected
+
+
+def test_get_torrent_status_save_path_expanded(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any, mock_config: Any
+):
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    dm = DownloadManager()
+    handle_mock = MagicMock()
+    handle_mock.is_valid.return_value = True
+
+    status_mock = MagicMock()
+    status_mock.state = lt.torrent_status.states.seeding
+    status_mock.progress = 1.0
+    status_mock.download_rate = 0
+    status_mock.upload_rate = 0
+    status_mock.total_wanted = 1000
+    status_mock.total_wanted_done = 1000
+    status_mock.flags = 0
+    status_mock.is_seeding = True
+    status_mock.is_finished = True
+    status_mock.has_metadata = True
+    status_mock.save_path = str(tmp_path)
+    status_mock.num_seeds = 1
+    status_mock.num_peers = 1
+    status_mock.list_seeds = 1
+    status_mock.list_peers = 1
+    status_mock.error_file = -1
+    status_mock.errc = None
+
+    # Create dummy file
+    test_file = Path(tmp_path) / "test.txt"
+    test_file.write_text("hello")
+
+    torrent_info_mock = MagicMock()
+    fs_mock = MagicMock()
+    fs_mock.num_files.return_value = 1
+    fs_mock.file_path.return_value = "test.txt"
+    fs_mock.file_flags.return_value = 0
+    torrent_info_mock.files.return_value = fs_mock
+    handle_mock.torrent_file.return_value = torrent_info_mock
+
+    handle_mock.status.return_value = status_mock
+    magnet = "magnet:?xt=urn:btih:mock_save_path_test"
+    dm.torrents = {magnet: handle_mock}
+
+    status = dm.get_torrent_status(magnet)
+    assert status is not None
+    assert status["is_missing_files"] is False
+

--- a/tests/test_core_download.py
+++ b/tests/test_core_download.py
@@ -386,4 +386,3 @@ def test_get_torrent_status_save_path_expanded(
     status = dm.get_torrent_status(magnet)
     assert status is not None
     assert status["is_missing_files"] is False
-

--- a/tests/test_core_download.py
+++ b/tests/test_core_download.py
@@ -348,6 +348,17 @@ def test_get_torrent_status_save_path_expanded(
     handle_mock = MagicMock()
     handle_mock.is_valid.return_value = True
 
+    # Setup dummy directory and file in tmp_path
+    sub_dir = Path(tmp_path) / "dl_folder"
+    sub_dir.mkdir()
+    test_file = sub_dir / "test.txt"
+    test_file.write_text("hello")
+
+    # Set up environment variables so path expansion is required
+    monkeypatch.setenv("TEST_STATUS_DIR", "dl_folder")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
     status_mock = MagicMock()
     status_mock.state = lt.torrent_status.states.seeding
     status_mock.progress = 1.0
@@ -359,17 +370,14 @@ def test_get_torrent_status_save_path_expanded(
     status_mock.is_seeding = True
     status_mock.is_finished = True
     status_mock.has_metadata = True
-    status_mock.save_path = str(tmp_path)
+    # Unexpanded path with tilde and environment variable
+    status_mock.save_path = "~/$TEST_STATUS_DIR"
     status_mock.num_seeds = 1
     status_mock.num_peers = 1
     status_mock.list_seeds = 1
     status_mock.list_peers = 1
     status_mock.error_file = -1
     status_mock.errc = None
-
-    # Create dummy file
-    test_file = Path(tmp_path) / "test.txt"
-    test_file.write_text("hello")
 
     torrent_info_mock = MagicMock()
     fs_mock = MagicMock()
@@ -381,6 +389,61 @@ def test_get_torrent_status_save_path_expanded(
 
     handle_mock.status.return_value = status_mock
     magnet = "magnet:?xt=urn:btih:mock_save_path_test"
+    dm.torrents = {magnet: handle_mock}
+
+    status = dm.get_torrent_status(magnet)
+    assert status is not None
+    assert status["is_missing_files"] is False
+
+
+def test_get_torrent_status_save_path_config_fallback_expanded(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any, mock_config: Any
+):
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    sub_dir = Path(tmp_path) / "cfg_downloads"
+    sub_dir.mkdir()
+    test_file = sub_dir / "test.txt"
+    test_file.write_text("hello")
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    mock_config.set("general.download_path", "~/cfg_downloads")
+
+    dm = DownloadManager()
+    handle_mock = MagicMock()
+    handle_mock.is_valid.return_value = True
+
+    status_mock = MagicMock()
+    status_mock.state = lt.torrent_status.states.seeding
+    status_mock.progress = 1.0
+    status_mock.download_rate = 0
+    status_mock.upload_rate = 0
+    status_mock.total_wanted = 1000
+    status_mock.total_wanted_done = 1000
+    status_mock.flags = 0
+    status_mock.is_seeding = True
+    status_mock.is_finished = True
+    status_mock.has_metadata = True
+    status_mock.save_path = ""  # empty so it triggers config fallback
+    status_mock.num_seeds = 1
+    status_mock.num_peers = 1
+    status_mock.list_seeds = 1
+    status_mock.list_peers = 1
+    status_mock.error_file = -1
+    status_mock.errc = None
+
+    torrent_info_mock = MagicMock()
+    fs_mock = MagicMock()
+    fs_mock.num_files.return_value = 1
+    fs_mock.file_path.return_value = "test.txt"
+    fs_mock.file_flags.return_value = 0
+    torrent_info_mock.files.return_value = fs_mock
+    handle_mock.torrent_file.return_value = torrent_info_mock
+
+    handle_mock.status.return_value = status_mock
+    magnet = "magnet:?xt=urn:btih:mock_save_path_cfg_test"
     dm.torrents = {magnet: handle_mock}
 
     status = dm.get_torrent_status(magnet)


### PR DESCRIPTION
## Description
Expands user tildes (`~`), environment variables, and resolves relative paths to absolute paths for `general.download_path` to prevent libtorrent from creating a literal `~` directory or misplacing downloads relative to the working directory.

## Changes
- Automatically expand `~`, env vars, and absolutize `general.download_path` in `Config.get()`.
- Normalize `save_path` in `DownloadManager.get_torrent_status()` before checking for missing files.
- Added unit tests in `test_core_config` and `test_core_download`.

Fixes #322
