### PR TITLE
fix: make file selection snapshot platform-independent

### DIFF
--- a/tests/snapshots/__snapshots__/test_screens/test_file_selection_screen_snapshot.raw
+++ b/tests/snapshots/__snapshots__/test_screens/test_file_selection_screen_snapshot.raw
@@ -19,165 +19,165 @@
         font-weight: 700;
     }
 
-    .terminal-3084390134-matrix {
+    .terminal-3222801968-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-3084390134-title {
+    .terminal-3222801968-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-3084390134-r1 { fill: #e0e0e0 }
-.terminal-3084390134-r2 { fill: #c5c8c6 }
-.terminal-3084390134-r3 { fill: #121212 }
-.terminal-3084390134-r4 { fill: #004578 }
-.terminal-3084390134-r5 { fill: #e0e0e0;font-weight: bold }
-.terminal-3084390134-r6 { fill: #929292 }
-.terminal-3084390134-r7 { fill: #929292;font-weight: bold }
-.terminal-3084390134-r8 { fill: #ddedf9;font-weight: bold }
-.terminal-3084390134-r9 { fill: #92c5ec;font-weight: bold }
-.terminal-3084390134-r10 { fill: #98e024 }
-.terminal-3084390134-r11 { fill: #a1a1a1 }
-.terminal-3084390134-r12 { fill: #6a6a6a }
+    .terminal-3222801968-r1 { fill: #e0e0e0 }
+.terminal-3222801968-r2 { fill: #c5c8c6 }
+.terminal-3222801968-r3 { fill: #121212 }
+.terminal-3222801968-r4 { fill: #004578 }
+.terminal-3222801968-r5 { fill: #e0e0e0;font-weight: bold }
+.terminal-3222801968-r6 { fill: #929292 }
+.terminal-3222801968-r7 { fill: #929292;font-weight: bold }
+.terminal-3222801968-r8 { fill: #ddedf9;font-weight: bold }
+.terminal-3222801968-r9 { fill: #92c5ec;font-weight: bold }
+.terminal-3222801968-r10 { fill: #98e024 }
+.terminal-3222801968-r11 { fill: #a1a1a1 }
+.terminal-3222801968-r12 { fill: #6a6a6a }
     </style>
 
     <defs>
-    <clipPath id="terminal-3084390134-clip-terminal">
+    <clipPath id="terminal-3222801968-clip-terminal">
       <rect x="0" y="0" width="1097.0" height="731.0" />
     </clipPath>
-    <clipPath id="terminal-3084390134-line-0">
+    <clipPath id="terminal-3222801968-line-0">
     <rect x="0" y="1.5" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-1">
+<clipPath id="terminal-3222801968-line-1">
     <rect x="0" y="25.9" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-2">
+<clipPath id="terminal-3222801968-line-2">
     <rect x="0" y="50.3" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-3">
+<clipPath id="terminal-3222801968-line-3">
     <rect x="0" y="74.7" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-4">
+<clipPath id="terminal-3222801968-line-4">
     <rect x="0" y="99.1" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-5">
+<clipPath id="terminal-3222801968-line-5">
     <rect x="0" y="123.5" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-6">
+<clipPath id="terminal-3222801968-line-6">
     <rect x="0" y="147.9" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-7">
+<clipPath id="terminal-3222801968-line-7">
     <rect x="0" y="172.3" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-8">
+<clipPath id="terminal-3222801968-line-8">
     <rect x="0" y="196.7" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-9">
+<clipPath id="terminal-3222801968-line-9">
     <rect x="0" y="221.1" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-10">
+<clipPath id="terminal-3222801968-line-10">
     <rect x="0" y="245.5" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-11">
+<clipPath id="terminal-3222801968-line-11">
     <rect x="0" y="269.9" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-12">
+<clipPath id="terminal-3222801968-line-12">
     <rect x="0" y="294.3" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-13">
+<clipPath id="terminal-3222801968-line-13">
     <rect x="0" y="318.7" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-14">
+<clipPath id="terminal-3222801968-line-14">
     <rect x="0" y="343.1" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-15">
+<clipPath id="terminal-3222801968-line-15">
     <rect x="0" y="367.5" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-16">
+<clipPath id="terminal-3222801968-line-16">
     <rect x="0" y="391.9" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-17">
+<clipPath id="terminal-3222801968-line-17">
     <rect x="0" y="416.3" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-18">
+<clipPath id="terminal-3222801968-line-18">
     <rect x="0" y="440.7" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-19">
+<clipPath id="terminal-3222801968-line-19">
     <rect x="0" y="465.1" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-20">
+<clipPath id="terminal-3222801968-line-20">
     <rect x="0" y="489.5" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-21">
+<clipPath id="terminal-3222801968-line-21">
     <rect x="0" y="513.9" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-22">
+<clipPath id="terminal-3222801968-line-22">
     <rect x="0" y="538.3" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-23">
+<clipPath id="terminal-3222801968-line-23">
     <rect x="0" y="562.7" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-24">
+<clipPath id="terminal-3222801968-line-24">
     <rect x="0" y="587.1" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-25">
+<clipPath id="terminal-3222801968-line-25">
     <rect x="0" y="611.5" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-26">
+<clipPath id="terminal-3222801968-line-26">
     <rect x="0" y="635.9" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-27">
+<clipPath id="terminal-3222801968-line-27">
     <rect x="0" y="660.3" width="1098" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3084390134-line-28">
+<clipPath id="terminal-3222801968-line-28">
     <rect x="0" y="684.7" width="1098" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1114" height="780" rx="8"/><text class="terminal-3084390134-title" fill="#c5c8c6" text-anchor="middle" x="557" y="27">torrra</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1114" height="780" rx="8"/><text class="terminal-3222801968-title" fill="#c5c8c6" text-anchor="middle" x="557" y="27">torrra</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-3084390134-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3222801968-clip-terminal)">
     <rect fill="#121212" x="0" y="1.5" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="74.7" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="99.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="99.1" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="99.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="123.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="123.5" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="475.8" y="123.5" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="622.2" y="123.5" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="123.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="123.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="147.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="147.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="305" y="147.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="427" y="147.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="463.6" y="147.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="573.4" y="147.9" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="658.8" y="147.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="780.8" y="147.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="147.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="147.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="172.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="172.3" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="172.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="172.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="196.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="207.4" y="196.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="292.8" y="196.7" width="610" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="196.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="196.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="221.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="219.6" y="221.1" width="658.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="878.4" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="221.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="221.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="245.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="245.5" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="245.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="245.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="269.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="207.4" y="269.9" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="378.2" y="269.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="488" y="269.9" width="402.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="269.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="269.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="294.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="207.4" y="294.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="244" y="294.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="427" y="294.3" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="536.8" y="294.3" width="353.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="294.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="294.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="318.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="207.4" y="318.7" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="318.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="318.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="343.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="207.4" y="343.1" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="343.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="343.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="367.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="207.4" y="367.5" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="367.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="367.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="391.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="207.4" y="391.9" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="391.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="391.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="416.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="207.4" y="416.3" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="416.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="416.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="440.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="207.4" y="440.7" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="440.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="440.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="465.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="207.4" y="465.1" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="465.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="465.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="489.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="207.4" y="489.5" width="683.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="890.6" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="489.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="489.5" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="513.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="513.9" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="513.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="513.9" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="538.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="538.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="256.2" y="538.3" width="585.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="841.8" y="538.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="538.3" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="538.3" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="562.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="562.7" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="231.8" y="562.7" width="622.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="854" y="562.7" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="562.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="562.7" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="587.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#004578" x="183" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="195.2" y="587.1" width="707.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="587.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="915" y="587.1" width="183" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="611.5" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="635.9" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="660.3" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="684.7" width="1098" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="709.1" width="1098" height="24.65" shape-rendering="crispEdges"/>
-    <g class="terminal-3084390134-matrix">
-    <text class="terminal-3084390134-r2" x="1098" y="20" textLength="12.2" clip-path="url(#terminal-3084390134-line-0)">
-</text><text class="terminal-3084390134-r2" x="1098" y="44.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-1)">
-</text><text class="terminal-3084390134-r2" x="1098" y="68.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-2)">
-</text><text class="terminal-3084390134-r2" x="1098" y="93.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-3)">
-</text><text class="terminal-3084390134-r3" x="183" y="117.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-4)">▊</text><text class="terminal-3084390134-r4" x="195.2" y="117.6" textLength="707.6" clip-path="url(#terminal-3084390134-line-4)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-3084390134-r4" x="902.8" y="117.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-4)">▎</text><text class="terminal-3084390134-r2" x="1098" y="117.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-4)">
-</text><text class="terminal-3084390134-r3" x="183" y="142" textLength="12.2" clip-path="url(#terminal-3084390134-line-5)">▊</text><text class="terminal-3084390134-r5" x="475.8" y="142" textLength="146.4" clip-path="url(#terminal-3084390134-line-5)">Linux&#160;Images</text><text class="terminal-3084390134-r4" x="902.8" y="142" textLength="12.2" clip-path="url(#terminal-3084390134-line-5)">▎</text><text class="terminal-3084390134-r2" x="1098" y="142" textLength="12.2" clip-path="url(#terminal-3084390134-line-5)">
-</text><text class="terminal-3084390134-r3" x="183" y="166.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-6)">▊</text><text class="terminal-3084390134-r6" x="305" y="166.4" textLength="122" clip-path="url(#terminal-3084390134-line-6)">Selected:&#160;</text><text class="terminal-3084390134-r7" x="427" y="166.4" textLength="36.6" clip-path="url(#terminal-3084390134-line-6)">2/2</text><text class="terminal-3084390134-r6" x="463.6" y="166.4" textLength="109.8" clip-path="url(#terminal-3084390134-line-6)">&#160;files&#160;·&#160;</text><text class="terminal-3084390134-r7" x="573.4" y="166.4" textLength="85.4" clip-path="url(#terminal-3084390134-line-6)">1.86&#160;GB</text><text class="terminal-3084390134-r6" x="658.8" y="166.4" textLength="122" clip-path="url(#terminal-3084390134-line-6)">&#160;/&#160;1.86&#160;GB</text><text class="terminal-3084390134-r4" x="902.8" y="166.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-6)">▎</text><text class="terminal-3084390134-r2" x="1098" y="166.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-6)">
-</text><text class="terminal-3084390134-r3" x="183" y="190.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-7)">▊</text><text class="terminal-3084390134-r4" x="902.8" y="190.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-7)">▎</text><text class="terminal-3084390134-r2" x="1098" y="190.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-7)">
-</text><text class="terminal-3084390134-r3" x="183" y="215.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-8)">▊</text><text class="terminal-3084390134-r6" x="207.4" y="215.2" textLength="85.4" clip-path="url(#terminal-3084390134-line-8)">Save&#160;to</text><text class="terminal-3084390134-r4" x="902.8" y="215.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-8)">▎</text><text class="terminal-3084390134-r2" x="1098" y="215.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-8)">
-</text><text class="terminal-3084390134-r3" x="183" y="239.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-9)">▊</text><text class="terminal-3084390134-r1" x="219.6" y="239.6" textLength="658.8" clip-path="url(#terminal-3084390134-line-9)">C:\downloads&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3084390134-r4" x="902.8" y="239.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-9)">▎</text><text class="terminal-3084390134-r2" x="1098" y="239.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-9)">
-</text><text class="terminal-3084390134-r3" x="183" y="264" textLength="12.2" clip-path="url(#terminal-3084390134-line-10)">▊</text><text class="terminal-3084390134-r4" x="902.8" y="264" textLength="12.2" clip-path="url(#terminal-3084390134-line-10)">▎</text><text class="terminal-3084390134-r2" x="1098" y="264" textLength="12.2" clip-path="url(#terminal-3084390134-line-10)">
-</text><text class="terminal-3084390134-r3" x="183" y="288.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-11)">▊</text><text class="terminal-3084390134-r8" x="207.4" y="288.4" textLength="170.8" clip-path="url(#terminal-3084390134-line-11)">[x]&#160;linux.iso&#160;</text><text class="terminal-3084390134-r9" x="378.2" y="288.4" textLength="109.8" clip-path="url(#terminal-3084390134-line-11)">(1.86&#160;GB)</text><text class="terminal-3084390134-r4" x="902.8" y="288.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-11)">▎</text><text class="terminal-3084390134-r2" x="1098" y="288.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-11)">
-</text><text class="terminal-3084390134-r3" x="183" y="312.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-12)">▊</text><text class="terminal-3084390134-r10" x="207.4" y="312.8" textLength="36.6" clip-path="url(#terminal-3084390134-line-12)">[x]</text><text class="terminal-3084390134-r1" x="244" y="312.8" textLength="183" clip-path="url(#terminal-3084390134-line-12)">&#160;checksums.txt&#160;</text><text class="terminal-3084390134-r11" x="427" y="312.8" textLength="109.8" clip-path="url(#terminal-3084390134-line-12)">(1.00&#160;KB)</text><text class="terminal-3084390134-r4" x="902.8" y="312.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-12)">▎</text><text class="terminal-3084390134-r2" x="1098" y="312.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-12)">
-</text><text class="terminal-3084390134-r3" x="183" y="337.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-13)">▊</text><text class="terminal-3084390134-r4" x="902.8" y="337.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-13)">▎</text><text class="terminal-3084390134-r2" x="1098" y="337.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-13)">
-</text><text class="terminal-3084390134-r3" x="183" y="361.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-14)">▊</text><text class="terminal-3084390134-r4" x="902.8" y="361.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-14)">▎</text><text class="terminal-3084390134-r2" x="1098" y="361.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-14)">
-</text><text class="terminal-3084390134-r3" x="183" y="386" textLength="12.2" clip-path="url(#terminal-3084390134-line-15)">▊</text><text class="terminal-3084390134-r4" x="902.8" y="386" textLength="12.2" clip-path="url(#terminal-3084390134-line-15)">▎</text><text class="terminal-3084390134-r2" x="1098" y="386" textLength="12.2" clip-path="url(#terminal-3084390134-line-15)">
-</text><text class="terminal-3084390134-r3" x="183" y="410.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-16)">▊</text><text class="terminal-3084390134-r4" x="902.8" y="410.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-16)">▎</text><text class="terminal-3084390134-r2" x="1098" y="410.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-16)">
-</text><text class="terminal-3084390134-r3" x="183" y="434.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-17)">▊</text><text class="terminal-3084390134-r4" x="902.8" y="434.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-17)">▎</text><text class="terminal-3084390134-r2" x="1098" y="434.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-17)">
-</text><text class="terminal-3084390134-r3" x="183" y="459.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-18)">▊</text><text class="terminal-3084390134-r4" x="902.8" y="459.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-18)">▎</text><text class="terminal-3084390134-r2" x="1098" y="459.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-18)">
-</text><text class="terminal-3084390134-r3" x="183" y="483.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-19)">▊</text><text class="terminal-3084390134-r4" x="902.8" y="483.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-19)">▎</text><text class="terminal-3084390134-r2" x="1098" y="483.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-19)">
-</text><text class="terminal-3084390134-r3" x="183" y="508" textLength="12.2" clip-path="url(#terminal-3084390134-line-20)">▊</text><text class="terminal-3084390134-r4" x="902.8" y="508" textLength="12.2" clip-path="url(#terminal-3084390134-line-20)">▎</text><text class="terminal-3084390134-r2" x="1098" y="508" textLength="12.2" clip-path="url(#terminal-3084390134-line-20)">
-</text><text class="terminal-3084390134-r3" x="183" y="532.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-21)">▊</text><text class="terminal-3084390134-r4" x="902.8" y="532.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-21)">▎</text><text class="terminal-3084390134-r2" x="1098" y="532.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-21)">
-</text><text class="terminal-3084390134-r3" x="183" y="556.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-22)">▊</text><text class="terminal-3084390134-r12" x="256.2" y="556.8" textLength="585.6" clip-path="url(#terminal-3084390134-line-22)">[space]&#160;toggle&#160;·&#160;[a]&#160;all&#160;·&#160;[n]&#160;none&#160;·&#160;[i]&#160;invert</text><text class="terminal-3084390134-r4" x="902.8" y="556.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-22)">▎</text><text class="terminal-3084390134-r2" x="1098" y="556.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-22)">
-</text><text class="terminal-3084390134-r3" x="183" y="581.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-23)">▊</text><text class="terminal-3084390134-r12" x="231.8" y="581.2" textLength="622.2" clip-path="url(#terminal-3084390134-line-23)">[h/l/←/→]&#160;folders&#160;·&#160;[enter]&#160;download&#160;·&#160;[esc]&#160;cancel</text><text class="terminal-3084390134-r4" x="902.8" y="581.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-23)">▎</text><text class="terminal-3084390134-r2" x="1098" y="581.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-23)">
-</text><text class="terminal-3084390134-r3" x="183" y="605.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-24)">▊</text><text class="terminal-3084390134-r4" x="195.2" y="605.6" textLength="707.6" clip-path="url(#terminal-3084390134-line-24)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-3084390134-r4" x="902.8" y="605.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-24)">▎</text><text class="terminal-3084390134-r2" x="1098" y="605.6" textLength="12.2" clip-path="url(#terminal-3084390134-line-24)">
-</text><text class="terminal-3084390134-r2" x="1098" y="630" textLength="12.2" clip-path="url(#terminal-3084390134-line-25)">
-</text><text class="terminal-3084390134-r2" x="1098" y="654.4" textLength="12.2" clip-path="url(#terminal-3084390134-line-26)">
-</text><text class="terminal-3084390134-r2" x="1098" y="678.8" textLength="12.2" clip-path="url(#terminal-3084390134-line-27)">
-</text><text class="terminal-3084390134-r2" x="1098" y="703.2" textLength="12.2" clip-path="url(#terminal-3084390134-line-28)">
+    <g class="terminal-3222801968-matrix">
+    <text class="terminal-3222801968-r2" x="1098" y="20" textLength="12.2" clip-path="url(#terminal-3222801968-line-0)">
+</text><text class="terminal-3222801968-r2" x="1098" y="44.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-1)">
+</text><text class="terminal-3222801968-r2" x="1098" y="68.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-2)">
+</text><text class="terminal-3222801968-r2" x="1098" y="93.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-3)">
+</text><text class="terminal-3222801968-r3" x="183" y="117.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-4)">▊</text><text class="terminal-3222801968-r4" x="195.2" y="117.6" textLength="707.6" clip-path="url(#terminal-3222801968-line-4)">▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔</text><text class="terminal-3222801968-r4" x="902.8" y="117.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-4)">▎</text><text class="terminal-3222801968-r2" x="1098" y="117.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-4)">
+</text><text class="terminal-3222801968-r3" x="183" y="142" textLength="12.2" clip-path="url(#terminal-3222801968-line-5)">▊</text><text class="terminal-3222801968-r5" x="475.8" y="142" textLength="146.4" clip-path="url(#terminal-3222801968-line-5)">Linux&#160;Images</text><text class="terminal-3222801968-r4" x="902.8" y="142" textLength="12.2" clip-path="url(#terminal-3222801968-line-5)">▎</text><text class="terminal-3222801968-r2" x="1098" y="142" textLength="12.2" clip-path="url(#terminal-3222801968-line-5)">
+</text><text class="terminal-3222801968-r3" x="183" y="166.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-6)">▊</text><text class="terminal-3222801968-r6" x="305" y="166.4" textLength="122" clip-path="url(#terminal-3222801968-line-6)">Selected:&#160;</text><text class="terminal-3222801968-r7" x="427" y="166.4" textLength="36.6" clip-path="url(#terminal-3222801968-line-6)">2/2</text><text class="terminal-3222801968-r6" x="463.6" y="166.4" textLength="109.8" clip-path="url(#terminal-3222801968-line-6)">&#160;files&#160;·&#160;</text><text class="terminal-3222801968-r7" x="573.4" y="166.4" textLength="85.4" clip-path="url(#terminal-3222801968-line-6)">1.86&#160;GB</text><text class="terminal-3222801968-r6" x="658.8" y="166.4" textLength="122" clip-path="url(#terminal-3222801968-line-6)">&#160;/&#160;1.86&#160;GB</text><text class="terminal-3222801968-r4" x="902.8" y="166.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-6)">▎</text><text class="terminal-3222801968-r2" x="1098" y="166.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-6)">
+</text><text class="terminal-3222801968-r3" x="183" y="190.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-7)">▊</text><text class="terminal-3222801968-r4" x="902.8" y="190.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-7)">▎</text><text class="terminal-3222801968-r2" x="1098" y="190.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-7)">
+</text><text class="terminal-3222801968-r3" x="183" y="215.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-8)">▊</text><text class="terminal-3222801968-r6" x="207.4" y="215.2" textLength="85.4" clip-path="url(#terminal-3222801968-line-8)">Save&#160;to</text><text class="terminal-3222801968-r4" x="902.8" y="215.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-8)">▎</text><text class="terminal-3222801968-r2" x="1098" y="215.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-8)">
+</text><text class="terminal-3222801968-r3" x="183" y="239.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-9)">▊</text><text class="terminal-3222801968-r1" x="219.6" y="239.6" textLength="658.8" clip-path="url(#terminal-3222801968-line-9)">/downloads&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3222801968-r4" x="902.8" y="239.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-9)">▎</text><text class="terminal-3222801968-r2" x="1098" y="239.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-9)">
+</text><text class="terminal-3222801968-r3" x="183" y="264" textLength="12.2" clip-path="url(#terminal-3222801968-line-10)">▊</text><text class="terminal-3222801968-r4" x="902.8" y="264" textLength="12.2" clip-path="url(#terminal-3222801968-line-10)">▎</text><text class="terminal-3222801968-r2" x="1098" y="264" textLength="12.2" clip-path="url(#terminal-3222801968-line-10)">
+</text><text class="terminal-3222801968-r3" x="183" y="288.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-11)">▊</text><text class="terminal-3222801968-r8" x="207.4" y="288.4" textLength="170.8" clip-path="url(#terminal-3222801968-line-11)">[x]&#160;linux.iso&#160;</text><text class="terminal-3222801968-r9" x="378.2" y="288.4" textLength="109.8" clip-path="url(#terminal-3222801968-line-11)">(1.86&#160;GB)</text><text class="terminal-3222801968-r4" x="902.8" y="288.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-11)">▎</text><text class="terminal-3222801968-r2" x="1098" y="288.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-11)">
+</text><text class="terminal-3222801968-r3" x="183" y="312.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-12)">▊</text><text class="terminal-3222801968-r10" x="207.4" y="312.8" textLength="36.6" clip-path="url(#terminal-3222801968-line-12)">[x]</text><text class="terminal-3222801968-r1" x="244" y="312.8" textLength="183" clip-path="url(#terminal-3222801968-line-12)">&#160;checksums.txt&#160;</text><text class="terminal-3222801968-r11" x="427" y="312.8" textLength="109.8" clip-path="url(#terminal-3222801968-line-12)">(1.00&#160;KB)</text><text class="terminal-3222801968-r4" x="902.8" y="312.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-12)">▎</text><text class="terminal-3222801968-r2" x="1098" y="312.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-12)">
+</text><text class="terminal-3222801968-r3" x="183" y="337.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-13)">▊</text><text class="terminal-3222801968-r4" x="902.8" y="337.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-13)">▎</text><text class="terminal-3222801968-r2" x="1098" y="337.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-13)">
+</text><text class="terminal-3222801968-r3" x="183" y="361.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-14)">▊</text><text class="terminal-3222801968-r4" x="902.8" y="361.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-14)">▎</text><text class="terminal-3222801968-r2" x="1098" y="361.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-14)">
+</text><text class="terminal-3222801968-r3" x="183" y="386" textLength="12.2" clip-path="url(#terminal-3222801968-line-15)">▊</text><text class="terminal-3222801968-r4" x="902.8" y="386" textLength="12.2" clip-path="url(#terminal-3222801968-line-15)">▎</text><text class="terminal-3222801968-r2" x="1098" y="386" textLength="12.2" clip-path="url(#terminal-3222801968-line-15)">
+</text><text class="terminal-3222801968-r3" x="183" y="410.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-16)">▊</text><text class="terminal-3222801968-r4" x="902.8" y="410.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-16)">▎</text><text class="terminal-3222801968-r2" x="1098" y="410.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-16)">
+</text><text class="terminal-3222801968-r3" x="183" y="434.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-17)">▊</text><text class="terminal-3222801968-r4" x="902.8" y="434.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-17)">▎</text><text class="terminal-3222801968-r2" x="1098" y="434.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-17)">
+</text><text class="terminal-3222801968-r3" x="183" y="459.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-18)">▊</text><text class="terminal-3222801968-r4" x="902.8" y="459.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-18)">▎</text><text class="terminal-3222801968-r2" x="1098" y="459.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-18)">
+</text><text class="terminal-3222801968-r3" x="183" y="483.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-19)">▊</text><text class="terminal-3222801968-r4" x="902.8" y="483.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-19)">▎</text><text class="terminal-3222801968-r2" x="1098" y="483.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-19)">
+</text><text class="terminal-3222801968-r3" x="183" y="508" textLength="12.2" clip-path="url(#terminal-3222801968-line-20)">▊</text><text class="terminal-3222801968-r4" x="902.8" y="508" textLength="12.2" clip-path="url(#terminal-3222801968-line-20)">▎</text><text class="terminal-3222801968-r2" x="1098" y="508" textLength="12.2" clip-path="url(#terminal-3222801968-line-20)">
+</text><text class="terminal-3222801968-r3" x="183" y="532.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-21)">▊</text><text class="terminal-3222801968-r4" x="902.8" y="532.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-21)">▎</text><text class="terminal-3222801968-r2" x="1098" y="532.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-21)">
+</text><text class="terminal-3222801968-r3" x="183" y="556.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-22)">▊</text><text class="terminal-3222801968-r12" x="256.2" y="556.8" textLength="585.6" clip-path="url(#terminal-3222801968-line-22)">[space]&#160;toggle&#160;·&#160;[a]&#160;all&#160;·&#160;[n]&#160;none&#160;·&#160;[i]&#160;invert</text><text class="terminal-3222801968-r4" x="902.8" y="556.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-22)">▎</text><text class="terminal-3222801968-r2" x="1098" y="556.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-22)">
+</text><text class="terminal-3222801968-r3" x="183" y="581.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-23)">▊</text><text class="terminal-3222801968-r12" x="231.8" y="581.2" textLength="622.2" clip-path="url(#terminal-3222801968-line-23)">[h/l/←/→]&#160;folders&#160;·&#160;[enter]&#160;download&#160;·&#160;[esc]&#160;cancel</text><text class="terminal-3222801968-r4" x="902.8" y="581.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-23)">▎</text><text class="terminal-3222801968-r2" x="1098" y="581.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-23)">
+</text><text class="terminal-3222801968-r3" x="183" y="605.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-24)">▊</text><text class="terminal-3222801968-r4" x="195.2" y="605.6" textLength="707.6" clip-path="url(#terminal-3222801968-line-24)">▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁</text><text class="terminal-3222801968-r4" x="902.8" y="605.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-24)">▎</text><text class="terminal-3222801968-r2" x="1098" y="605.6" textLength="12.2" clip-path="url(#terminal-3222801968-line-24)">
+</text><text class="terminal-3222801968-r2" x="1098" y="630" textLength="12.2" clip-path="url(#terminal-3222801968-line-25)">
+</text><text class="terminal-3222801968-r2" x="1098" y="654.4" textLength="12.2" clip-path="url(#terminal-3222801968-line-26)">
+</text><text class="terminal-3222801968-r2" x="1098" y="678.8" textLength="12.2" clip-path="url(#terminal-3222801968-line-27)">
+</text><text class="terminal-3222801968-r2" x="1098" y="703.2" textLength="12.2" clip-path="url(#terminal-3222801968-line-28)">
 </text>
     </g>
     </g>

--- a/tests/snapshots/test_screens.py
+++ b/tests/snapshots/test_screens.py
@@ -111,10 +111,8 @@ def test_help_screen_snapshot(app_factory: Any, snap_compare: Any):
 
 def test_file_selection_screen_snapshot(
     app_factory: Any,
-    mock_config: Config,
     snap_compare: Any,
 ):
-    mock_config.set("general.download_path", "/downloads")
     torrent_info = MagicMock()
     torrent_info.name.return_value = "Linux Images"
     files = MagicMock()
@@ -139,6 +137,7 @@ def test_file_selection_screen_snapshot(
                     source="Snapshot",
                 ),
                 torrent_info=torrent_info,
+                initial_save_path="/downloads",
             )
         )
         await pilot.pause()


### PR DESCRIPTION
Passes explicit initial_save_path to FileSelectionScreen in snapshot tests and updates the stored raw snapshot so tests pass consistently across Windows and Linux.