### PR TITLE
fix: mock session stats to prevent DHT flakes in snapshot tests

### DIFF
--- a/tests/snapshots/conftest.py
+++ b/tests/snapshots/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from torrra._types import SessionStats
+from torrra.core.download import DownloadManager
+
+
+@pytest.fixture(autouse=True)
+def mock_session_stats(monkeypatch: pytest.MonkeyPatch):
+    """Ensure deterministic session stats in snapshot tests to prevent DHT flakes."""
+    monkeypatch.setattr(
+        DownloadManager,
+        "get_session_stats",
+        lambda self: SessionStats(
+            download_rate=0.0,
+            upload_rate=0.0,
+            dht_nodes=0,
+        ),
+    )


### PR DESCRIPTION
## Summary
Adds an autouse fixture in `tests/snapshots/conftest.py` that monkeypatches `DownloadManager.get_session_stats()` to return deterministic zeroes.

### Details
- Prevents intermittent snapshot test failures caused by live `libtorrent` DHT nodes bootstrapping in the background during screen renders.
- Scoped to `tests/snapshots/` so non-snapshot unit tests remain unaffected.

### Testing
- `uv run pytest tests/snapshots` (6 passed)
- `uv run pytest` (266 passed)
- `uv run ruff check` & `uv run ty check` (clean)