### PR TITLE
feat: improve details panel layout, ETA placement, and shortcuts

### DIFF
--- a/src/torrra/app.tcss
+++ b/src/torrra/app.tcss
@@ -44,10 +44,24 @@ DetailsPanel {
   &:focus {
     border: solid $secondary;
   }
+  #details_progress_row {
+    height: auto;
+    width: 100%;
+    align-vertical: middle;
+  }
   ProgressBar {
+    width: 1fr;
     #bar {
       width: 1fr;
     }
+  }
+  #details_eta {
+    width: auto;
+    margin-left: 1;
+  }
+  #details_shortcuts {
+    height: auto;
+    color: $foreground-muted;
   }
 }
 

--- a/src/torrra/widgets/details_panel.py
+++ b/src/torrra/widgets/details_panel.py
@@ -1,5 +1,5 @@
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.message import Message
 from textual.widgets import ProgressBar, Static
 from typing_extensions import override
@@ -15,17 +15,24 @@ class DetailsPanel(Vertical):
         # UI refs
         self._content_widget: Static
         self._progress_bar: ProgressBar | None = None
+        self._eta_widget: Static | None = None
+        self._shortcuts_widget: Static
 
     @override
     def compose(self) -> ComposeResult:
-        yield Static()
+        yield Static(id="details_content")
         if self.show_progress_bar:
-            yield ProgressBar(total=100, show_eta=False)
+            with Horizontal(id="details_progress_row"):
+                yield ProgressBar(total=100, show_eta=False)
+                yield Static(id="details_eta")
+        yield Static(id="details_shortcuts")
 
     def on_mount(self) -> None:
-        self._content_widget = self.query_one(Static)
+        self._content_widget = self.query_one("#details_content", Static)
         if self.show_progress_bar:
             self._progress_bar = self.query_one(ProgressBar)
+            self._eta_widget = self.query_one("#details_eta", Static)
+        self._shortcuts_widget = self.query_one("#details_shortcuts", Static)
         # enable focus for this widget
         self.can_focus: bool = True
 
@@ -33,7 +40,17 @@ class DetailsPanel(Vertical):
         self.add_class("hidden")
         self.post_message(self.Closed())
 
-    def update_content(self, content: str, progress: float | None = None) -> None:
+    def update_content(
+        self,
+        content: str,
+        progress: float | None = None,
+        eta: str | None = None,
+        shortcuts: str | None = None,
+    ) -> None:
         self._content_widget.update(content)
         if self._progress_bar and progress is not None:
             self._progress_bar.progress = progress
+        if self._eta_widget and eta is not None:
+            self._eta_widget.update(f"ETA: [b]{eta}[/b]" if eta else "")
+        if shortcuts is not None:
+            self._shortcuts_widget.update(shortcuts)

--- a/src/torrra/widgets/downloads.py
+++ b/src/torrra/widgets/downloads.py
@@ -416,12 +416,12 @@ class DownloadsContent(Vertical):
         eta_text = human_readable_eta(status["eta"], is_seeding=status["is_seeding"])
         limits = self._dm.get_torrent_limits(self._selected_torrent["magnet_uri"])
         up_limit_suffix = (
-            f" [{human_readable_size(limits[0], short=True)}/s]"
+            f" [dim][{human_readable_size(limits[0], short=True)}/s][/dim]"
             if limits and limits[0] is not None and limits[0] > 0
             else ""
         )
         down_limit_suffix = (
-            f" [{human_readable_size(limits[1], short=True)}/s]"
+            f" [dim][{human_readable_size(limits[1], short=True)}/s][/dim]"
             if limits and limits[1] is not None and limits[1] > 0
             else ""
         )
@@ -431,16 +431,20 @@ class DownloadsContent(Vertical):
         seeders_text = f"{status.get('seeders', 0)}/{status.get('total_seeders', 0)}"
         peers_text = f"{status.get('peers', 0)}/{status.get('total_peers', 0)}"
         save_path = escape(status["save_path"])
-        details = f"""
-[b]Size:[/b] {size} · [b]Status:[/b] {state_text} · [b]Source:[/b] {current_torrent["source"]}
-[b]Seeders:[/b] {seeders_text} · [b]Peers:[/b] {peers_text} · [b]Up:[/b] {up_speed} · [b]Down:[/b] {down_speed} · [b]ETA:[/b] {eta_text}
-[b]Save to:[/b] {save_path}
-
-[dim]\\[p] pause/resume · \\[f] select files · \\[s] speed limit · \\[d] delete · \\[D] delete w/ data · \\[esc] close[/dim]
-"""
+        details = (
+            f"Status: [b]{state_text}[/b] [dim]·[/dim] Size: {size} [dim]·[/dim] [dim]Source:[/dim] [dim]{current_torrent['source']}[/dim]\n"
+            f"Down: [b]{down_speed}[/b] [dim]·[/dim] Up: {up_speed} [dim]·[/dim] [dim]Seeds:[/dim] [dim]{seeders_text}[/dim] [dim]·[/dim] [dim]Peers:[/dim] [dim]{peers_text}[/dim]\n"
+            f"[dim]Save to:[/dim] [dim]{save_path}[/dim]"
+        )
+        shortcuts = (
+            r"[dim]\[p] pause/resume · \[f] select files · \[s] speed limit · "
+            r"\[d] delete · \[D] delete w/ data · \[esc] close[/dim]"
+        )
         # update details panel internal widgets
         self._details_panel.border_title = current_torrent["title"]
         self._details_panel.update_content(
-            details.strip(),
+            details,
             progress=status["progress"],
+            eta=eta_text,
+            shortcuts=shortcuts,
         )

--- a/tests/test_widgets_details_panel.py
+++ b/tests/test_widgets_details_panel.py
@@ -1,0 +1,58 @@
+from textual.app import App, ComposeResult
+from textual.widgets import ProgressBar, Static
+
+from torrra.widgets.details_panel import DetailsPanel
+
+
+class DetailsPanelTestApp(App[None]):
+    def __init__(self, show_progress_bar: bool = False) -> None:
+        super().__init__()
+        self.show_progress_bar = show_progress_bar
+
+    def compose(self) -> ComposeResult:
+        yield DetailsPanel(show_progress_bar=self.show_progress_bar)
+
+
+async def test_details_panel_without_progress_bar():
+    app = DetailsPanelTestApp(show_progress_bar=False)
+    async with app.run_test() as pilot:
+        panel = app.query_one(DetailsPanel)
+        assert panel.has_class("hidden")
+        assert len(panel.query(ProgressBar)) == 0
+        assert len(panel.query("#details_eta")) == 0
+
+        panel.update_content("Test info")
+        content = panel.query_one("#details_content", Static)
+        assert "Test info" in str(content.content)
+
+        # escape closes the panel
+        panel.remove_class("hidden")
+        panel.focus()
+        await pilot.press("escape")
+        assert panel.has_class("hidden")
+
+
+async def test_details_panel_with_progress_bar_and_eta():
+    app = DetailsPanelTestApp(show_progress_bar=True)
+    async with app.run_test():
+        panel = app.query_one(DetailsPanel)
+        assert len(panel.query(ProgressBar)) == 1
+        assert len(panel.query("#details_eta")) == 1
+        assert len(panel.query("#details_shortcuts")) == 1
+
+        panel.update_content(
+            "Torrent Details",
+            progress=65.5,
+            eta="12m 30s",
+            shortcuts="[p] pause · [d] delete",
+        )
+        content = panel.query_one("#details_content", Static)
+        progress_bar = panel.query_one(ProgressBar)
+        eta_widget = panel.query_one("#details_eta", Static)
+        shortcuts_widget = panel.query_one("#details_shortcuts", Static)
+
+        assert "Torrent Details" in str(content.content)
+        assert progress_bar.progress == 65.5
+        assert "ETA:" in str(eta_widget.content)
+        assert "12m 30s" in str(eta_widget.content)
+        assert "[p] pause · [d] delete" in str(shortcuts_widget.content)


### PR DESCRIPTION
## Description
- Move torrent ETA display beside the progress bar in the details panel for better space efficiency and visual association.
- Relocate keyboard shortcuts to a dedicated footer below the progress bar.
- Improve visual hierarchy in the details panel with dim/muted labels, delimiters, and secondary metadata while emphasizing key metrics (Status, Down speed, Progress, ETA).
- Add unit tests for \DetailsPanel\.

## Changes
- \src/torrra/widgets/details_panel.py\: Add horizontal progress row with ETA and bottom shortcuts widget.
- \src/torrra/widgets/downloads.py\: Update details metadata formatting and pass ETA + shortcuts to details panel.
- \src/torrra/app.tcss\: Style \#details_progress_row\, \ProgressBar\, \#details_eta\, and \#details_shortcuts\.
- \	ests/test_widgets_details_panel.py\: Add unit tests for \DetailsPanel\.