### PR TITLE
feat: auto-size file selection modal and hide save path during metadata loading

### DIFF
--- a/src/torrra/app.tcss
+++ b/src/torrra/app.tcss
@@ -309,13 +309,16 @@ SortSelectorScreen {
 FileSelectionScreen {
   align: center middle;
   #file-selection-container {
-    height: 21;
+    height: auto;
     max-height: 80%;
     width: 60;
     max-width: 85%;
     background: $surface;
     border: tall $secondary;
     padding: 0 1;
+    &.loaded {
+      height: 21;
+    }
     #file-selection-header {
       height: auto;
       margin-bottom: 1;
@@ -342,10 +345,11 @@ FileSelectionScreen {
       }
     }
     #file-selection-loading {
-      height: 1fr;
+      height: auto;
       #loading-spinner-area {
-        height: 1fr;
+        height: auto;
         align: center middle;
+        margin-bottom: 1;
         Static {
           text-align: center;
           content-align-horizontal: center;

--- a/src/torrra/screens/file_selection.py
+++ b/src/torrra/screens/file_selection.py
@@ -291,6 +291,7 @@ class FileSelectionScreen(ModalScreen[DownloadSelection | None]):
         self._pad_file_indices: set[int] = set()
         self._poll_timer: Timer | None = None
 
+        self._container: Vertical
         self._selection_list: FileSelectionTree
         self._stats_label: Static
         self._torrent_name_label: Static
@@ -298,28 +299,35 @@ class FileSelectionScreen(ModalScreen[DownloadSelection | None]):
         self._loading_container: Vertical
         self._body_container: Vertical
         self._footer_container: Vertical
+        self._save_path_label: Static | None = None
         self._save_path_input: Input | None = None
         self._default_save_path: Path | None = None
 
     @override
     def compose(self) -> ComposeResult:
         action_verb = "save" if self.is_edit_mode else "download"
-        with Vertical(id="file-selection-container"):
+        container_classes = "loaded" if self._torrent_info is not None else ""
+        save_path_classes = "" if self._torrent_info is not None else "hidden"
+        with Vertical(id="file-selection-container", classes=container_classes):
             with Vertical(id="file-selection-header"):
                 yield Static(self.torrent.title, id="torrent-name")
                 yield Static("Loading file list...", id="selection-stats")
                 if not self.is_edit_mode:
-                    yield Static("Save to", id="save-path-label")
+                    yield Static(
+                        "Save to", id="save-path-label", classes=save_path_classes
+                    )
                     yield Input(
                         value=self.initial_save_path or "",
                         placeholder="Absolute path",
                         id="save-path",
+                        classes=save_path_classes,
                     )
 
             with Vertical(id="file-selection-loading"):
                 with Vertical(id="loading-spinner-area"):
                     yield Static(
-                        "Fetching torrent metadata...", id="loading-status-text"
+                        "Fetching torrent metadata...\n[dim](peers: 0)[/dim]",
+                        id="loading-status-text",
                     )
                     yield Spinner(name="material")
                 yield Static(
@@ -337,6 +345,7 @@ class FileSelectionScreen(ModalScreen[DownloadSelection | None]):
                 )
 
     def on_mount(self) -> None:
+        self._container = self.query_one("#file-selection-container", Vertical)
         self._selection_list = self.query_one(FileSelectionTree)
         self._stats_label = self.query_one("#selection-stats", Static)
         self._torrent_name_label = self.query_one("#torrent-name", Static)
@@ -345,6 +354,7 @@ class FileSelectionScreen(ModalScreen[DownloadSelection | None]):
         self._body_container = self.query_one("#file-selection-body", Vertical)
         self._footer_container = self.query_one("#file-selection-footer", Vertical)
         if not self.is_edit_mode:
+            self._save_path_label = self.query_one("#save-path-label", Static)
             self._save_path_input = self.query_one("#save-path", Input)
             if self.initial_save_path is None:
                 try:
@@ -406,7 +416,9 @@ class FileSelectionScreen(ModalScreen[DownloadSelection | None]):
         self._loading_status_label.update(
             "Choose a valid download directory, then press [b]enter[/b]."
         )
-        if self._save_path_input is not None:
+        if self._save_path_input is not None and not self._save_path_input.has_class(
+            "hidden"
+        ):
             self._save_path_input.focus()
 
     def _poll_metadata(self) -> None:
@@ -471,9 +483,17 @@ class FileSelectionScreen(ModalScreen[DownloadSelection | None]):
         )
 
         # Switch UI from loading to loaded
+        self._container.add_class("loaded")
         self._loading_container.add_class("hidden")
         self._body_container.remove_class("hidden")
         self._footer_container.remove_class("hidden")
+        if (
+            not self.is_edit_mode
+            and self._save_path_label is not None
+            and self._save_path_input is not None
+        ):
+            self._save_path_label.remove_class("hidden")
+            self._save_path_input.remove_class("hidden")
 
         self._update_stats()
         self._selection_list.focus()

--- a/tests/screens/test_file_selection.py
+++ b/tests/screens/test_file_selection.py
@@ -897,3 +897,59 @@ async def test_home_does_not_recreate_missing_custom_save_path(tmp_path: Any):
 
         assert magnet not in get_download_manager().torrents
         assert not destination.exists()
+
+
+async def test_file_selection_container_height_transitions_from_auto_to_fixed():
+    torrent = Torrent(
+        magnet_uri="magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567",
+        title="Loading Test Torrent",
+        size=1024,
+        seeders=10,
+        leechers=2,
+        source="Mock",
+    )
+
+    screen = FileSelectionScreen(torrent=torrent)
+    app = DummyHostApp(screen)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        container = screen.query_one("#file-selection-container")
+        assert not container.has_class("loaded")
+        assert not screen.query_one("#file-selection-loading").has_class("hidden")
+        assert screen.query_one("#file-selection-body").has_class("hidden")
+        assert screen.query_one("#save-path", Input).has_class("hidden")
+        assert screen.query_one("#save-path-label", Static).has_class("hidden")
+
+        # Simulate metadata loaded
+        mock_ti = create_mock_torrent_info()
+        screen._populate_files(mock_ti)
+        await pilot.pause()
+
+        assert container.has_class("loaded")
+        assert screen.query_one("#file-selection-loading").has_class("hidden")
+        assert not screen.query_one("#file-selection-body").has_class("hidden")
+        assert not screen.query_one("#save-path", Input).has_class("hidden")
+        assert not screen.query_one("#save-path-label", Static).has_class("hidden")
+
+
+async def test_file_selection_container_loaded_class_when_torrent_info_provided():
+    mock_ti = create_mock_torrent_info()
+    torrent = Torrent(
+        magnet_uri="magnet:?xt=urn:btih:mocktest",
+        title="Ubuntu 24.04 Pack",
+        size=2_500_003_072,
+        seeders=10,
+        leechers=2,
+        source="Mock",
+    )
+
+    screen = FileSelectionScreen(torrent=torrent, torrent_info=mock_ti)
+    app = DummyHostApp(screen)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        container = screen.query_one("#file-selection-container")
+        assert container.has_class("loaded")
+        assert not screen.query_one("#save-path", Input).has_class("hidden")
+        assert not screen.query_one("#save-path-label", Static).has_class("hidden")


### PR DESCRIPTION
## Summary
- Dynamic auto-sizing for `FileSelectionScreen` modal container while fetching metadata, transitioning to fixed height (`21`) once loaded.
- Hide "Save to" label and path input while fetching metadata, revealing them alongside the file tree upon load.

## Changes
- `src/torrra/app.tcss`: Default `#file-selection-container` to `height: auto` and add `&.loaded { height: 21; }`.
- `src/torrra/screens/file_selection.py`: Hide save path elements during loading; toggle `.loaded` and unhide save path in `_populate_files()`.
- `tests/screens/test_file_selection.py`: Add test coverage for modal container states and save path visibility.