### PR TITLE
feat: show downloaded amount alongside total size in details panel

### DIFF
--- a/src/torrra/_types.py
+++ b/src/torrra/_types.py
@@ -25,6 +25,7 @@ class TorrentStatus(TypedDict, total=False):
     progress: float
     down_speed: float
     up_speed: float
+    total_done: int
     seeders: int
     total_seeders: int
     leechers: int

--- a/src/torrra/core/download.py
+++ b/src/torrra/core/download.py
@@ -448,12 +448,18 @@ class DownloadManager:
         total_seeds = max(connected_seeds, getattr(s, "list_seeds", 0))
         connected_peers = getattr(s, "num_peers", 0)
         total_peers = max(connected_peers, getattr(s, "list_peers", 0))
+        total_done = (
+            int(s.total_done)
+            if hasattr(s, "total_done") and isinstance(s.total_done, (int, float))
+            else 0
+        )
 
         return TorrentStatus(
             state=s.state,
             progress=s.progress * 100,
             down_speed=s.download_rate,
             up_speed=s.upload_rate,
+            total_done=total_done,
             seeders=connected_seeds,
             total_seeders=total_seeds,
             leechers=connected_peers,

--- a/src/torrra/widgets/downloads.py
+++ b/src/torrra/widgets/downloads.py
@@ -412,7 +412,17 @@ class DownloadsContent(Vertical):
         )
 
         state_text = self._dm.get_torrent_state_text(status)
-        size = human_readable_size(float(current_torrent["size"]))
+        total_size = float(current_torrent["size"])
+        downloaded = status.get("total_done")
+        if downloaded is None or downloaded == 0:
+            downloaded = (status.get("progress", 0.0) / 100.0) * total_size
+        else:
+            downloaded = float(downloaded)
+
+        if total_size > 0:
+            downloaded = min(downloaded, total_size)
+
+        size = f"{human_readable_size(downloaded)} / {human_readable_size(total_size)}"
         eta_text = human_readable_eta(status["eta"], is_seeding=status["is_seeding"])
         limits = self._dm.get_torrent_limits(self._selected_torrent["magnet_uri"])
         up_limit_suffix = (


### PR DESCRIPTION
## Summary
Displays the downloaded amount alongside the total size in the torrent details panel in the format `Size: <download> / <og_size>`.

## Changes
- `src/torrra/_types.py`: Add `total_done: int` to `TorrentStatus` TypedDict.
- `src/torrra/core/download.py`: Extract `total_done` from libtorrent status in `DownloadManager.get_torrent_status()`.
- `src/torrra/widgets/downloads.py`: Update `_update_details_panel()` to format the size as `<download> / <og_size>`.