### PR TITLE
feat: support human-readable speed limit defaults

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,8 +34,8 @@ default_sort_order = "auto"                   # Direction for the initial sort: 
 min_seeders = 0                               # Hide results with fewer seeders than this. 0 shows everything.
 
 [speed_limit]
-upload_limit = 10240                          # Global upload cap in bytes/sec (turtle mode). 0 = unlimited.
-download_limit = 10240                        # Global download cap in bytes/sec (turtle mode). 0 = unlimited.
+upload_limit = "10 KB/s"                        # Global upload cap (turtle mode). e.g. "10 KB/s", "500K", "2M", "unlimited" or 0.
+download_limit = "10 KB/s"                      # Global download cap (turtle mode). e.g. "10 KB/s", "2M", "unlimited" or 0.
 enabled = false                               # Whether turtle mode is currently active. Toggled at runtime with the `t` key.
 
 [indexers]
@@ -59,9 +59,9 @@ The `[speed_limit]` section defines session-wide bandwidth caps, similar to
 
 ```toml
 [speed_limit]
-upload_limit = 1048576    # bytes/sec (1 MB/s); 0 = unlimited
-download_limit = 2097152  # bytes/sec (2 MB/s); 0 = unlimited
-enabled = false           # whether turtle mode is currently active
+upload_limit = "1 MB/s"       # global upload cap; "unlimited" or 0 = no cap
+download_limit = "2 MB/s"     # global download cap; "unlimited" or 0 = no cap
+enabled = false               # whether turtle mode is currently active
 ```
 
 When `enabled` is `true`, all traffic in every `torrra` session is capped at

--- a/src/torrra/core/config.py
+++ b/src/torrra/core/config.py
@@ -198,18 +198,19 @@ class Config:
 
             new_value: Any = value
             # speed limit keys accept human-readable units ("500K", "2M",
-            # "1.5 GB/s"); store normalized bytes/sec so readers can rely
-            # on ints ("unlimited"/"0" normalize to 0)
+            # "1.5 GB/s", "10 KB/s", "unlimited"); validate with parse_speed_limit
+            # and store the string representation
             if key_path in (
                 "speed_limit.upload_limit",
                 "speed_limit.download_limit",
             ):
                 try:
-                    new_value = max(0, parse_speed_limit(value))
+                    parse_speed_limit(value)
+                    new_value = str(value).strip()
                 except ValueError as e:
                     raise ConfigError(
                         f"invalid value for '{key_path}': {value!r} ({e}). "
-                        + "use e.g. 500K, 2M, or a bare bytes/sec number"
+                        + "use e.g. 500K, 2M, 10 KB/s, or unlimited"
                     ) from e
             # handle case-insensitive "true"/"false" for booleans
             elif value.lower() == "true":

--- a/src/torrra/core/constants.py
+++ b/src/torrra/core/constants.py
@@ -6,8 +6,8 @@ DEFAULT_SORT = "relevance"
 # while seeders reads high-to-low. an explicit "asc"/"desc" overrides that.
 DEFAULT_SORT_ORDER = "auto"
 DEFAULT_MIN_SEEDERS = 0
-# global (session-wide) bandwidth caps in bytes/sec; 0 = unlimited.
-# toggled at runtime with the "t" keybind ("turtle mode"). defaults mirror
-# qBittorrent's alternative-speed limits (10 KB/s in both directions).
-DEFAULT_SPEED_LIMIT_UPLOAD = 10 * 1024
-DEFAULT_SPEED_LIMIT_DOWNLOAD = 10 * 1024
+# global (session-wide) bandwidth caps; defaults mirror qBittorrent's
+# alternative-speed limits (10 KB/s in both directions). accepts human-readable
+# units ("10 KB/s", "2M", "500K") or bare bytes/sec numbers; 0/unlimited = no cap.
+DEFAULT_SPEED_LIMIT_UPLOAD = "10 KB/s"
+DEFAULT_SPEED_LIMIT_DOWNLOAD = "10 KB/s"

--- a/src/torrra/utils/helpers.py
+++ b/src/torrra/utils/helpers.py
@@ -91,16 +91,16 @@ def parse_speed_limit(text: str) -> int:
 def coerce_speed_limit(value: object) -> int:
     """Coerce a stored speed-limit config value to bytes/second.
 
-    Ints pass through unchanged; strings (e.g. a hand-edited ``"2M"`` in
-    config.toml) are parsed, and anything unparsable falls back to ``0``
-    (unlimited) instead of crashing readers.
+    Ints pass through (normalized to >= 0); strings (e.g. ``"10 KB/s"``, ``"2M"``
+    in config.toml) are parsed, and anything unparsable or unlimited (``"0"``,
+    ``"unlimited"``) falls back to ``0`` instead of crashing readers.
     """
     if isinstance(value, bool):
         return 0
     if isinstance(value, int):
-        return value
+        return max(0, value)
     try:
-        return parse_speed_limit(str(value))
+        return max(0, parse_speed_limit(str(value)))
     except ValueError:
         return 0
 

--- a/tests/screens/test_speed_limit.py
+++ b/tests/screens/test_speed_limit.py
@@ -136,7 +136,7 @@ async def test_global_speed_toggle_uses_default_limits_when_unconfigured(
 ):
     # a fresh config already ships with 10 KB/s turtle limits, so pressing
     # "t" applies them immediately without prompting
-    assert mock_config.get("speed_limit.upload_limit") == 10 * 1024
+    assert mock_config.get("speed_limit.upload_limit") == "10 KB/s"
 
     app = app_factory(search_query="arch linux iso")
     async with app.run_test() as pilot:

--- a/tests/test_core_config.py
+++ b/tests/test_core_config.py
@@ -10,6 +10,7 @@ from torrra.core.constants import (
     DEFAULT_SPEED_LIMIT_UPLOAD,
 )
 from torrra.core.exceptions import ConfigError
+from torrra.utils.helpers import coerce_speed_limit
 
 
 def test_config_initialization_creates_default_file(mock_config: Config):
@@ -63,27 +64,41 @@ def test_config_set_type_conversion(mock_config: Config):
 
 def test_default_speed_limits_are_turtle_values(mock_config: Config):
     # fresh config ships with qBittorrent-style 10 KB/s turtle limits
-    assert DEFAULT_SPEED_LIMIT_UPLOAD == 10 * 1024
-    assert DEFAULT_SPEED_LIMIT_DOWNLOAD == 10 * 1024
+    assert DEFAULT_SPEED_LIMIT_UPLOAD == "10 KB/s"
+    assert DEFAULT_SPEED_LIMIT_DOWNLOAD == "10 KB/s"
     assert mock_config.get("speed_limit.upload_limit") == DEFAULT_SPEED_LIMIT_UPLOAD
     assert mock_config.get("speed_limit.download_limit") == DEFAULT_SPEED_LIMIT_DOWNLOAD
+    # readers like download manager and status bar coerce to bytes/sec
+    assert coerce_speed_limit(mock_config.get("speed_limit.upload_limit")) == 10 * 1024
+    assert (
+        coerce_speed_limit(mock_config.get("speed_limit.download_limit")) == 10 * 1024
+    )
 
 
 def test_config_set_speed_limit_parses_human_units(mock_config: Config):
-    # speed limit keys accept human-readable units and store bytes/sec
+    # speed limit keys validate human-readable units and store string values
     mock_config.set("speed_limit.download_limit", "2M")
     mock_config.set("speed_limit.upload_limit", "500K")
     mock_config.set("speed_limit.download_limit", "1.5 GB/s")
 
-    # last write wins
-    assert mock_config.get("speed_limit.download_limit") == int(1.5 * 1024**3)
-    assert mock_config.get("speed_limit.upload_limit") == 500 * 1024
+    # last write wins, string preserved in config
+    assert mock_config.get("speed_limit.download_limit") == "1.5 GB/s"
+    assert mock_config.get("speed_limit.upload_limit") == "500K"
+    assert coerce_speed_limit(mock_config.get("speed_limit.download_limit")) == int(
+        1.5 * 1024**3
+    )
+    assert coerce_speed_limit(mock_config.get("speed_limit.upload_limit")) == 500 * 1024
 
 
 def test_config_set_speed_limit_unlimited_and_invalid(mock_config: Config):
-    # "unlimited"/"0" normalize to 0 bytes/sec
+    # "unlimited"/"0" store the string, and coerce to 0 bytes/sec
     mock_config.set("speed_limit.upload_limit", "unlimited")
-    assert mock_config.get("speed_limit.upload_limit") == 0
+    assert mock_config.get("speed_limit.upload_limit") == "unlimited"
+    assert coerce_speed_limit(mock_config.get("speed_limit.upload_limit")) == 0
+
+    mock_config.set("speed_limit.upload_limit", "0")
+    assert mock_config.get("speed_limit.upload_limit") == "0"
+    assert coerce_speed_limit(mock_config.get("speed_limit.upload_limit")) == 0
 
     with pytest.raises(ConfigError, match="invalid value"):
         mock_config.set("speed_limit.download_limit", "abc")

--- a/tests/test_utils_helpers.py
+++ b/tests/test_utils_helpers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from torrra.utils.helpers import (
+    coerce_speed_limit,
     get_tomllib,
     human_readable_eta,
     human_readable_size,
@@ -89,11 +90,24 @@ def test_parse_speed_limit_per_sec_suffix():
 
 
 def test_parse_speed_limit_invalid():
-    import pytest
-
     with pytest.raises(ValueError):
         parse_speed_limit("abc")
     with pytest.raises(ValueError):
         parse_speed_limit("-5")
     with pytest.raises(ValueError):
         parse_speed_limit("10X")
+
+
+def test_coerce_speed_limit():
+    assert coerce_speed_limit(10240) == 10240
+    assert coerce_speed_limit("10 KB/s") == 10 * 1024
+    assert coerce_speed_limit("2M") == 2 * 1024**2
+    assert coerce_speed_limit("500K") == 500 * 1024
+    assert coerce_speed_limit("0") == 0
+    assert coerce_speed_limit("unlimited") == 0
+    assert coerce_speed_limit("off") == 0
+    assert coerce_speed_limit(0) == 0
+    assert coerce_speed_limit(-100) == 0
+    assert coerce_speed_limit(False) == 0
+    assert coerce_speed_limit(True) == 0
+    assert coerce_speed_limit("invalid-unit") == 0


### PR DESCRIPTION
## Summary
- Use human-readable string defaults (`10 KB/s`) for `speed_limit.upload_limit` and `speed_limit.download_limit` in `constants.py` and default `config.toml`.
- Preserve input strings in `Config.set()` after validation with `parse_speed_limit()`.
- Normalize return values in `coerce_speed_limit()` to non-negative integer bytes/sec for libtorrent and UI widgets.
- Backward compatible with existing configs containing integer byte values.
