### PR TITLE
fix: speed limit handling and metadata fetching optimizations

### DIFF
--- a/src/torrra/core/download.py
+++ b/src/torrra/core/download.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import atexit
 import os
+from contextlib import suppress
 from functools import lru_cache
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import libtorrent as lt
 
@@ -74,32 +75,31 @@ class DownloadManager:
         self.apply_global_limits()
         atexit.register(self.save_session_state)
 
-    def _create_session(self, settings: dict[str, Any]) -> lt.session:
+    def _create_session(self, settings: lt.settings_pack) -> lt.session:
         session_file = DB_DIR / "session.dat"
         if session_file.is_file():
-            try:
+            with suppress(
+                AttributeError, RuntimeError, OSError, TypeError, ValueError
+            ):
                 data = session_file.read_bytes()
                 if data and hasattr(lt, "read_session_params"):
                     params = lt.read_session_params(data)
                     session = lt.session(params)
                     session.apply_settings(settings)
                     return session
-            except Exception:
-                pass
         return lt.session(settings)
 
     def save_session_state(self) -> None:
-        try:
+        with suppress(
+            AttributeError, RuntimeError, OSError, TypeError, ValueError
+        ):
             DB_DIR.mkdir(parents=True, exist_ok=True)
             if hasattr(self.session, "session_state") and hasattr(
                 lt, "write_session_params_buf"
             ):
                 state = self.session.session_state()
-                if isinstance(state, lt.session_params):
-                    buf = lt.write_session_params_buf(state)
-                    (DB_DIR / "session.dat").write_bytes(buf)
-        except Exception:
-            pass
+                buf = lt.write_session_params_buf(state)
+                (DB_DIR / "session.dat").write_bytes(buf)
 
     def add_torrent(
         self,

--- a/src/torrra/core/download.py
+++ b/src/torrra/core/download.py
@@ -78,9 +78,7 @@ class DownloadManager:
     def _create_session(self, settings: lt.settings_pack) -> lt.session:
         session_file = DB_DIR / "session.dat"
         if session_file.is_file():
-            with suppress(
-                AttributeError, RuntimeError, OSError, TypeError, ValueError
-            ):
+            with suppress(AttributeError, RuntimeError, OSError, TypeError, ValueError):
                 data = session_file.read_bytes()
                 if data and hasattr(lt, "read_session_params"):
                     params = lt.read_session_params(data)
@@ -90,9 +88,7 @@ class DownloadManager:
         return lt.session(settings)
 
     def save_session_state(self) -> None:
-        with suppress(
-            AttributeError, RuntimeError, OSError, TypeError, ValueError
-        ):
+        with suppress(AttributeError, RuntimeError, OSError, TypeError, ValueError):
             DB_DIR.mkdir(parents=True, exist_ok=True)
             if hasattr(self.session, "session_state") and hasattr(
                 lt, "write_session_params_buf"

--- a/src/torrra/core/download.py
+++ b/src/torrra/core/download.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import atexit
 import os
 from functools import lru_cache
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import libtorrent as lt
 
@@ -12,6 +13,7 @@ from torrra.core.constants import (
     DEFAULT_SPEED_LIMIT_DOWNLOAD,
     DEFAULT_SPEED_LIMIT_UPLOAD,
 )
+from torrra.core.db import DB_DIR
 from torrra.core.exceptions import DownloadError
 from torrra.core.paths import normalize_download_path, prepare_download_path
 from torrra.utils.helpers import coerce_speed_limit
@@ -35,17 +37,31 @@ class DownloadManager:
 
     def __init__(self) -> None:
         settings: lt.settings_pack = {
-            "listen_interfaces": "0.0.0.0:6881,[::]:6881,0.0.0.0:0",
+            "listen_interfaces": "0.0.0.0:6881,[::]:6881,0.0.0.0:0,[::]:0",
             "enable_dht": True,
-            "dht_bootstrap_nodes": "router.bittorrent.com:6881,dht.transmissionbt.com:6881,router.utorrent.com:6881,dht.libtorrent.org:25401",
+            "dht_bootstrap_nodes": (
+                "dht.libtorrent.org:25401,"
+                "dht.transmissionbt.com:6881,"
+                "router.bittorrent.com:6881,"
+                "dht.aelitis.com:6881,"
+                "router.utorrent.com:6881"
+            ),
             "enable_lsd": True,
             "enable_upnp": True,
             "enable_natpmp": True,
             "announce_to_all_trackers": True,
             "announce_to_all_tiers": True,
             "prefer_udp_trackers": True,
+            "active_downloads": 50,
+            "active_limit": 500,
+            "connection_speed": 100,
+            "torrent_connect_boost": 100,
+            "peer_connect_timeout": 7,
+            "tracker_completion_timeout": 10,
+            "tracker_receive_timeout": 5,
+            "dht_search_branching": 10,
         }
-        self.session: lt.session = lt.session(settings)
+        self.session: lt.session = self._create_session(settings)
         self.torrents: dict[str, lt.torrent_handle] = {}
         self._metadata_only_torrents: set[str] = set()
         self._file_priorities: dict[str, list[int]] = {}
@@ -56,6 +72,34 @@ class DownloadManager:
         # apply session-wide speed limits from config ("turtle mode"),
         # a no-op when disabled or unset
         self.apply_global_limits()
+        atexit.register(self.save_session_state)
+
+    def _create_session(self, settings: dict[str, Any]) -> lt.session:
+        session_file = DB_DIR / "session.dat"
+        if session_file.is_file():
+            try:
+                data = session_file.read_bytes()
+                if data and hasattr(lt, "read_session_params"):
+                    params = lt.read_session_params(data)
+                    session = lt.session(params)
+                    session.apply_settings(settings)
+                    return session
+            except Exception:
+                pass
+        return lt.session(settings)
+
+    def save_session_state(self) -> None:
+        try:
+            DB_DIR.mkdir(parents=True, exist_ok=True)
+            if hasattr(self.session, "session_state") and hasattr(
+                lt, "write_session_params_buf"
+            ):
+                state = self.session.session_state()
+                if isinstance(state, lt.session_params):
+                    buf = lt.write_session_params_buf(state)
+                    (DB_DIR / "session.dat").write_bytes(buf)
+        except Exception:
+            pass
 
     def add_torrent(
         self,
@@ -197,6 +241,12 @@ class DownloadManager:
         self.torrents[magnet_uri] = handle
         if metadata_only:
             self._metadata_only_torrents.add(magnet_uri)
+            try:
+                handle.queue_position_top()
+                handle.force_reannounce()
+                handle.force_dht_announce()
+            except (AttributeError, RuntimeError):
+                pass
 
         # apply any stored per-torrent speed limits
         self._apply_stored_limits(handle, magnet_uri)
@@ -272,6 +322,16 @@ class DownloadManager:
         # 0 means unlimited, which is also libtorrent's sentinel value,
         # so values pass through unchanged. caps coexist with per-torrent
         # limits (the effective rate is the lower of the two).
+        # when turtle mode is disabled (the default), rate limits are 0 (unlimited).
+        if not self.is_speed_limit_enabled():
+            try:
+                self.session.apply_settings(
+                    {"upload_rate_limit": 0, "download_rate_limit": 0}
+                )
+            except (AttributeError, RuntimeError):
+                pass
+            return
+
         config = get_config()
         up = coerce_speed_limit(
             config.get("speed_limit.upload_limit", DEFAULT_SPEED_LIMIT_UPLOAD)
@@ -294,15 +354,7 @@ class DownloadManager:
 
     def set_speed_limit_enabled(self, enabled: bool) -> None:
         get_config().set("speed_limit.enabled", str(enabled).lower())
-        if enabled:
-            self.apply_global_limits()
-        else:
-            try:
-                self.session.apply_settings(
-                    {"upload_rate_limit": 0, "download_rate_limit": 0}
-                )
-            except (AttributeError, RuntimeError):
-                pass
+        self.apply_global_limits()
 
     def _apply_stored_limits(self, handle: lt.torrent_handle, magnet_uri: str) -> None:
         limits = self._limits.get(magnet_uri)

--- a/src/torrra/utils/magnet.py
+++ b/src/torrra/utils/magnet.py
@@ -6,13 +6,26 @@ import httpx
 import libtorrent as lt
 
 DEFAULT_TRACKERS: list[str] = [
+    "udp://zer0day.ch:1337/announce",
+    "udp://tracker.publictracker.xyz:6969/announce",
     "udp://tracker.opentrackr.org:1337/announce",
+    "udp://open.demonii.com:1337/announce",
     "udp://open.stealth.si:80/announce",
     "udp://tracker.torrent.eu.org:451/announce",
+    "udp://tracker.qu.ax:6969/announce",
+    "udp://tracker.peerfect.org:6969/announce",
+    "udp://tracker.opentrackr.com:6969/announce",
+    "udp://tracker.ilibr.org:6969/announce",
+    "udp://tracker.auctor.tv:6969/announce",
+    "udp://tracker-udp.gbitt.info:80/announce",
+    "udp://torrentclub.online:54123/announce",
+    "udp://torrentclub.online:1984/announce",
+    "udp://t.overflow.biz:6969/announce",
+    "udp://retracker01-msk-virt.corbina.net:80/announce",
+    "udp://mail.segso.net:6969/announce",
+    "udp://leet-tracker.moe:1337/announce",
+    "udp://ipv4announce.sktorrent.eu:6969/announce",
     "udp://explodie.org:6969/announce",
-    "udp://tracker.openbittorrent.com:6969/announce",
-    "udp://tracker.cyberia.is:6969/announce",
-    "http://tracker.openbittorrent.com:80/announce",
 ]
 
 

--- a/tests/test_core_download.py
+++ b/tests/test_core_download.py
@@ -409,6 +409,41 @@ def test_torrent_limits_persisted_to_db():
     assert record.get("download_limit") == 2048
 
 
+def test_global_speed_limits_disabled_by_default():
+    dm = DownloadManager()
+    assert dm.is_speed_limit_enabled() is False
+    settings = dm.session.get_settings()
+    assert settings["download_rate_limit"] == 0
+    assert settings["upload_rate_limit"] == 0
+
+
+def test_global_speed_limits_toggle():
+    dm = DownloadManager()
+    dm.set_speed_limit_enabled(True)
+    assert dm.is_speed_limit_enabled() is True
+    settings = dm.session.get_settings()
+    assert settings["download_rate_limit"] == 10240
+    assert settings["upload_rate_limit"] == 10240
+
+    dm.set_speed_limit_enabled(False)
+    assert dm.is_speed_limit_enabled() is False
+    settings = dm.session.get_settings()
+    assert settings["download_rate_limit"] == 0
+    assert settings["upload_rate_limit"] == 0
+
+
+def test_global_speed_limits_enabled_on_startup(mock_config):
+    mock_config.set("speed_limit.enabled", "true")
+    mock_config.set("speed_limit.download_limit", "2M")
+    mock_config.set("speed_limit.upload_limit", "500K")
+
+    dm = DownloadManager()
+    assert dm.is_speed_limit_enabled() is True
+    settings = dm.session.get_settings()
+    assert settings["download_rate_limit"] == 2 * 1024 * 1024
+    assert settings["upload_rate_limit"] == 500 * 1024
+
+
 def test_get_session_stats():
     dm = DownloadManager()
     stats = dm.get_session_stats()
@@ -651,3 +686,23 @@ def test_get_torrent_status_save_path_config_fallback_expanded(
     status = dm.get_torrent_status(magnet)
     assert status is not None
     assert status["is_missing_files"] is False
+
+
+def test_save_and_load_session_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from torrra.core import db as db_module
+
+    session_dir = tmp_path / "test_db_dir"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(db_module, "DB_DIR", session_dir)
+    monkeypatch.setattr("torrra.core.download.DB_DIR", session_dir)
+
+    dm = DownloadManager()
+    dm.save_session_state()
+
+    session_file = session_dir / "session.dat"
+    assert session_file.exists()
+    assert session_file.stat().st_size > 0
+
+    # Test loading existing session file
+    dm2 = DownloadManager()
+    assert dm2.session is not None


### PR DESCRIPTION
## Summary

- Fix unconditional speed limit application on startup by respecting speed_limit.enabled.
- Persist libtorrent session and DHT state across application restarts.
- Tune session connection settings and update DEFAULT_TRACKERS with the ngosang best tracker list.
- Prioritize metadata-fetching torrent handles with top queue position and forced announces.