### PR TITLE
fix: retain scroll position in details panel tables during periodic updates

### DIFF
--- a/src/torrra/app.tcss
+++ b/src/torrra/app.tcss
@@ -47,6 +47,7 @@ DetailsPanel {
   &.tabbed {
     height: 14;
     max-height: 45%;
+    padding: 0;
   }
   #details_tabs {
     height: 1fr;
@@ -54,6 +55,7 @@ DetailsPanel {
     ContentTabs {
       height: 2;
       background: transparent;
+      padding: 0 1;
       Tab {
         background: transparent;
         padding: 0 1;
@@ -71,6 +73,7 @@ DetailsPanel {
     }
     #tab_general {
       height: 1fr;
+      padding: 0 1;
       #details_content {
         height: auto;
       }
@@ -105,6 +108,7 @@ DetailsPanel {
   }
   #details_shortcuts {
     height: auto;
+    padding: 0 1;
     color: $foreground-muted;
   }
 }

--- a/src/torrra/widgets/details_panel.py
+++ b/src/torrra/widgets/details_panel.py
@@ -14,6 +14,7 @@ from textual.widgets import (
     TabPane,
     Tabs,
 )
+from textual.widgets.data_table import CellDoesNotExist
 from typing_extensions import override
 
 from torrra._types import PeerInfo, TorrentFileProgress, TrackerInfo
@@ -233,11 +234,35 @@ class DetailsPanel(Vertical):
         if shortcuts is not None:
             self._shortcuts_widget.update(shortcuts)
 
+    def clear_tables(self) -> None:
+        """Clear all detail tables when switching between torrents."""
+        if self._peers_table:
+            self._peers_table.clear()
+        if self._trackers_table:
+            self._trackers_table.clear()
+        if self._files_table:
+            self._files_table.clear()
+
+    @staticmethod
+    def _update_cell_if_changed(
+        table: DataTable[str], row_key: str, col_key: str, value: str
+    ) -> None:
+        try:
+            if table.get_cell(row_key, col_key) != value:
+                table.update_cell(row_key, col_key, value)
+        except (CellDoesNotExist, KeyError):
+            table.update_cell(row_key, col_key, value)
+
     def update_peers(self, peers: list[PeerInfo]) -> None:
         if not self._peers_table:
             return
-        self._peers_table.clear()
         if not peers:
+            if (
+                len(self._peers_table.rows) == 1
+                and "__empty__" in self._peers_table.rows
+            ):
+                return
+            self._peers_table.clear()
             self._peers_table.add_row(
                 "[dim]No connected peers[/dim]",
                 "[dim]-[/dim]",
@@ -245,9 +270,17 @@ class DetailsPanel(Vertical):
                 "[dim]-[/dim]",
                 "[dim]-[/dim]",
                 "[dim]-[/dim]",
+                key="__empty__",
             )
             return
-        for p in peers:
+
+        if "__empty__" in self._peers_table.rows:
+            self._peers_table.remove_row("__empty__")
+
+        incoming_keys: set[str] = set()
+        for idx, p in enumerate(peers):
+            key = p.get("ip") or f"peer_{idx}"
+            incoming_keys.add(key)
             down_speed = p.get("down_speed", 0.0)
             up_speed = p.get("up_speed", 0.0)
             down_str = f"{human_readable_size(down_speed, short=True)}/s"
@@ -255,20 +288,34 @@ class DetailsPanel(Vertical):
             down = f"[b]{down_str}[/b]" if down_speed > 0 else f"[dim]{down_str}[/dim]"
             up = f"{up_str}" if up_speed > 0 else f"[dim]{up_str}[/dim]"
             done = f"[b]{int(p.get('progress', 0.0))}%[/b]"
-            self._peers_table.add_row(
-                f"[dim]{p.get('ip', '0.0.0.0')}[/dim]",
-                p.get("client", "Unknown"),
-                down,
-                up,
-                done,
-                f"[dim]{p.get('flags', '-')}[/dim]",
-            )
+            client = p.get("client", "Unknown")
+            flags = f"[dim]{p.get('flags', '-')}[/dim]"
+            ip = f"[dim]{key}[/dim]"
+
+            if key in self._peers_table.rows:
+                self._update_cell_if_changed(self._peers_table, key, "client", client)
+                self._update_cell_if_changed(self._peers_table, key, "down", down)
+                self._update_cell_if_changed(self._peers_table, key, "up", up)
+                self._update_cell_if_changed(self._peers_table, key, "done", done)
+                self._update_cell_if_changed(self._peers_table, key, "flags", flags)
+            else:
+                self._peers_table.add_row(ip, client, down, up, done, flags, key=key)
+
+        existing_keys = [str(r.value) for r in self._peers_table.rows]
+        for r_key in existing_keys:
+            if r_key not in incoming_keys:
+                self._peers_table.remove_row(r_key)
 
     def update_trackers(self, trackers: list[TrackerInfo]) -> None:
         if not self._trackers_table:
             return
-        self._trackers_table.clear()
         if not trackers:
+            if (
+                len(self._trackers_table.rows) == 1
+                and "__empty__" in self._trackers_table.rows
+            ):
+                return
+            self._trackers_table.clear()
             self._trackers_table.add_row(
                 "[dim]-[/dim]",
                 "[dim]No trackers found (DHT / PeX only)[/dim]",
@@ -276,9 +323,20 @@ class DetailsPanel(Vertical):
                 "[dim]-[/dim]",
                 "[dim]-[/dim]",
                 "[dim]-[/dim]",
+                key="__empty__",
             )
             return
-        for t in trackers:
+
+        if "__empty__" in self._trackers_table.rows:
+            self._trackers_table.remove_row("__empty__")
+
+        incoming_keys: set[str] = set()
+        for idx, t in enumerate(trackers):
+            tier_val = t.get("tier", 0)
+            url = t.get("url", "")
+            key = f"{tier_val}_{url}" if url else str(idx)
+            incoming_keys.add(key)
+
             status_raw = t.get("status", "Unknown")
             if status_raw == "Working":
                 status = "[green]Working[/green]"
@@ -297,37 +355,71 @@ class DetailsPanel(Vertical):
             )
             peers_count = t.get("peers", 0)
             peers = f"{peers_count}" if peers_count > 0 else f"[dim]{peers_count}[/dim]"
+            msg = f"[dim]{t.get('message', '')}[/dim]"
+            tier = f"[dim]{tier_val}[/dim]"
 
-            self._trackers_table.add_row(
-                f"[dim]{t.get('tier', 0)}[/dim]",
-                t.get("url", ""),
-                status,
-                seeds,
-                peers,
-                f"[dim]{t.get('message', '')}[/dim]",
-            )
+            if key in self._trackers_table.rows:
+                self._update_cell_if_changed(
+                    self._trackers_table, key, "status", status
+                )
+                self._update_cell_if_changed(self._trackers_table, key, "seeds", seeds)
+                self._update_cell_if_changed(self._trackers_table, key, "peers", peers)
+                self._update_cell_if_changed(self._trackers_table, key, "message", msg)
+            else:
+                self._trackers_table.add_row(
+                    tier, url, status, seeds, peers, msg, key=key
+                )
+
+        existing_keys = [str(r.value) for r in self._trackers_table.rows]
+        for r_key in existing_keys:
+            if r_key not in incoming_keys:
+                self._trackers_table.remove_row(r_key)
 
     def update_files(self, files: list[TorrentFileProgress] | None) -> None:
         if not self._files_table:
             return
-        self._files_table.clear()
         if files is None:
+            if (
+                len(self._files_table.rows) == 1
+                and "__loading__" in self._files_table.rows
+            ):
+                return
+            self._files_table.clear()
             self._files_table.add_row(
                 "[dim]Fetching torrent metadata...[/dim]",
                 "[dim]-[/dim]",
                 "[dim]-[/dim]",
                 "[dim]-[/dim]",
+                key="__loading__",
             )
             return
+
         if not files:
+            if (
+                len(self._files_table.rows) == 1
+                and "__empty__" in self._files_table.rows
+            ):
+                return
+            self._files_table.clear()
             self._files_table.add_row(
                 "[dim]No files found[/dim]",
                 "[dim]-[/dim]",
                 "[dim]-[/dim]",
                 "[dim]-[/dim]",
+                key="__empty__",
             )
             return
-        for f in files:
+
+        if "__loading__" in self._files_table.rows:
+            self._files_table.remove_row("__loading__")
+        if "__empty__" in self._files_table.rows:
+            self._files_table.remove_row("__empty__")
+
+        incoming_keys: set[str] = set()
+        for idx, f in enumerate(files):
+            key = str(f.get("index", idx))
+            incoming_keys.add(key)
+
             prio_label = f.get("priority_label", "Normal")
             if prio_label == "High":
                 prio = "[b]High[/b]"
@@ -340,10 +432,16 @@ class DetailsPanel(Vertical):
             done = (
                 f"[b]{progress_val}%[/b]" if progress_val == 100 else f"{progress_val}%"
             )
+            path = f.get("path", "")
+            size = f"[dim]{human_readable_size(f.get('size', 0))}[/dim]"
 
-            self._files_table.add_row(
-                f.get("path", ""),
-                f"[dim]{human_readable_size(f.get('size', 0))}[/dim]",
-                done,
-                prio,
-            )
+            if key in self._files_table.rows:
+                self._update_cell_if_changed(self._files_table, key, "done", done)
+                self._update_cell_if_changed(self._files_table, key, "priority", prio)
+            else:
+                self._files_table.add_row(path, size, done, prio, key=key)
+
+        existing_keys = [str(r.value) for r in self._files_table.rows]
+        for r_key in existing_keys:
+            if r_key not in incoming_keys:
+                self._files_table.remove_row(r_key)

--- a/src/torrra/widgets/details_panel.py
+++ b/src/torrra/widgets/details_panel.py
@@ -294,9 +294,11 @@ class DetailsPanel(Vertical):
 
             if key in self._peers_table.rows:
                 self._update_cell_if_changed(self._peers_table, key, "client", client)
-                self._update_cell_if_changed(self._peers_table, key, "down", down)
-                self._update_cell_if_changed(self._peers_table, key, "up", up)
-                self._update_cell_if_changed(self._peers_table, key, "done", done)
+                self._update_cell_if_changed(self._peers_table, key, "down_speed", down)
+                self._update_cell_if_changed(self._peers_table, key, "up_speed", up)
+                self._update_cell_if_changed(
+                    self._peers_table, key, "done_percent", done
+                )
                 self._update_cell_if_changed(self._peers_table, key, "flags", flags)
             else:
                 self._peers_table.add_row(ip, client, down, up, done, flags, key=key)

--- a/src/torrra/widgets/downloads.py
+++ b/src/torrra/widgets/downloads.py
@@ -323,9 +323,12 @@ class DownloadsContent(Vertical):
         self, event: AutoResizingDataTable.RowSelected
     ) -> None:
         row_key = cast(str, event.row_key.value)
-        self._selected_torrent = next(
+        new_torrent = next(
             (d for d in self._torrents if d["magnet_uri"] == row_key), None
         )
+        if self._selected_torrent != new_torrent:
+            self._details_panel.clear_tables()
+        self._selected_torrent = new_torrent
 
         if self._selected_torrent:
             self._details_panel.border_title = self._selected_torrent["title"]

--- a/tests/screens/test_home.py
+++ b/tests/screens/test_home.py
@@ -810,6 +810,10 @@ async def test_downloads_details_panel_interaction(monkeypatch, mock_config):
     handle_mock.get_file_priorities.return_value = [1]
     handle_mock.upload_limit.return_value = 0
     handle_mock.download_limit.return_value = 0
+    info_mock = MagicMock()
+    info_mock.name.return_value = "Details Test Torrent"
+    info_mock.total_size.return_value = 1048576
+    handle_mock.torrent_file.return_value = info_mock
     dm.torrents[magnet] = handle_mock
 
     app = TorrraApp(

--- a/tests/test_widgets_details_panel.py
+++ b/tests/test_widgets_details_panel.py
@@ -154,3 +154,76 @@ async def test_details_panel_tabs_and_data_tables():
         # Escape closes panel
         await pilot.press("escape")
         assert panel.has_class("hidden")
+
+
+async def test_details_panel_in_place_updates_and_scroll_retention():
+    from textual.widgets import DataTable
+
+    from torrra._types import PeerInfo
+
+    app = DetailsPanelTestApp(show_progress_bar=True)
+    async with app.run_test() as pilot:
+        panel = app.query_one(DetailsPanel)
+        peers_table = panel.query_one("#peers_table", DataTable)
+
+        # Generate 20 peers
+        initial_peers = [
+            PeerInfo(
+                ip=f"10.0.0.{i}:6881",
+                client=f"Client/{i}",
+                down_speed=1000.0 * i,
+                up_speed=500.0 * i,
+                progress=float(i * 4),
+                flags="I",
+            )
+            for i in range(20)
+        ]
+        panel.update_peers(initial_peers)
+        assert len(peers_table.rows) == 20
+
+        # Scroll down in the table
+        peers_table.scroll_to(y=5, animate=False)
+        await pilot.pause()
+        assert peers_table.scroll_y == 5
+
+        # Update peers in-place (same peer list, updated speeds/progress)
+        updated_peers = [
+            PeerInfo(
+                ip=f"10.0.0.{i}:6881",
+                client=f"Client/{i}",
+                down_speed=2000.0 * i,
+                up_speed=1000.0 * i,
+                progress=float(i * 4 + 1),
+                flags="IO",
+            )
+            for i in range(20)
+        ]
+        panel.update_peers(updated_peers)
+        await pilot.pause()
+
+        # Row count unchanged and scroll offset retained!
+        assert len(peers_table.rows) == 20
+        assert peers_table.scroll_y == 5
+
+        # Remove peer 0, add new peer 99
+        updated_peers = updated_peers[1:] + [
+            PeerInfo(
+                ip="10.0.0.99:6881",
+                client="Client/99",
+                down_speed=5000.0,
+                up_speed=1000.0,
+                progress=99.0,
+                flags="IO",
+            )
+        ]
+        panel.update_peers(updated_peers)
+        await pilot.pause()
+
+        assert len(peers_table.rows) == 20
+        assert "10.0.0.99:6881" in peers_table.rows
+        assert "10.0.0.0:6881" not in peers_table.rows
+        assert peers_table.scroll_y == 5
+
+        # Clear tables
+        panel.clear_tables()
+        assert len(peers_table.rows) == 0

--- a/tests/test_widgets_details_panel.py
+++ b/tests/test_widgets_details_panel.py
@@ -157,14 +157,20 @@ async def test_details_panel_tabs_and_data_tables():
 
 
 async def test_details_panel_in_place_updates_and_scroll_retention():
-    from textual.widgets import DataTable
+    from textual.widgets import DataTable, TabbedContent
 
     from torrra._types import PeerInfo
 
     app = DetailsPanelTestApp(show_progress_bar=True)
     async with app.run_test() as pilot:
         panel = app.query_one(DetailsPanel)
+        panel.remove_class("hidden")
+        tc = panel.query_one(TabbedContent)
+        tc.active = "tab_peers"
+        await pilot.pause()
+
         peers_table = panel.query_one("#peers_table", DataTable)
+        peers_table.styles.height = 10
 
         # Generate 20 peers
         initial_peers = [
@@ -180,6 +186,7 @@ async def test_details_panel_in_place_updates_and_scroll_retention():
         ]
         panel.update_peers(initial_peers)
         assert len(peers_table.rows) == 20
+        await pilot.pause()
 
         # Scroll down in the table
         peers_table.scroll_to(y=5, animate=False)


### PR DESCRIPTION
### Summary
Fixes the issue where scrolling down tables in the torrent details panel (Peers, Trackers, Files) would jump back to the top whenever the 1-second polling update occurred.

### Cause
Previously, `update_peers()`, `update_trackers()`, and `update_files()` called `table.clear()` on every tick, which emptied all rows and reset Textual's viewport `scroll_y` offset to 0.

### Fix
- **In-place row updates (Key Diffing)**: Assigned unique row keys (`peer.ip`, `tracker.url`, `file.index`).
- On each tick:
  - Existing rows are updated in-place via `table.update_cell(...)` only when cell contents change, leaving the table's DOM and scroll offset untouched.
  - New entries are appended via `table.add_row(..., key=key)`.
  - Disconnected entries are removed via `table.remove_row(...)`.
- Added `clear_tables()` to `DetailsPanel` called when selecting a different torrent to ensure data refreshes cleanly between torrents.
- Added comprehensive unit tests in `tests/test_widgets_details_panel.py` verifying scroll position retention and in-place row updates.
