### PR TITLE
feat: resolve peer client name via BEP 20 peer id and extended handshake

### DIFF
--- a/src/torrra/_types.py
+++ b/src/torrra/_types.py
@@ -96,6 +96,7 @@ class PeerInfo(TypedDict, total=False):
     """Information for a single connected peer."""
 
     ip: str
+    port: int
     client: str
     down_speed: float
     up_speed: float

--- a/src/torrra/core/download.py
+++ b/src/torrra/core/download.py
@@ -30,6 +30,7 @@ from torrra.utils.helpers import (
     coerce_ratio_limit,
     coerce_seeding_time,
     coerce_speed_limit,
+    parse_peer_client,
 )
 from torrra.utils.magnet import enhance_magnet_uri, fix_magnet_uri
 
@@ -632,7 +633,9 @@ class DownloadManager:
                     else:
                         ip_str = str(ip_val)
 
-                client_str = getattr(p, "client", "") or "Unknown"
+                client_str = parse_peer_client(
+                    getattr(p, "client", None), getattr(p, "pid", None)
+                )
                 down_speed = float(
                     getattr(p, "down_speed", 0.0)
                     or getattr(p, "payload_down_speed", 0.0)

--- a/src/torrra/core/download.py
+++ b/src/torrra/core/download.py
@@ -626,12 +626,23 @@ class DownloadManager:
             peers: list[PeerInfo] = []
             for p in peer_list:
                 ip_str = "0.0.0.0"
+                port_val = 0
                 if hasattr(p, "ip"):
                     ip_val = p.ip
                     if isinstance(ip_val, tuple) and len(ip_val) == 2:
-                        ip_str = f"{ip_val[0]}:{ip_val[1]}"
+                        ip_str = str(ip_val[0])
+                        port_val = int(ip_val[1])
                     else:
-                        ip_str = str(ip_val)
+                        ip_val_str = str(ip_val)
+                        if ":" in ip_val_str and not ip_val_str.startswith("["):
+                            parts = ip_val_str.rsplit(":", 1)
+                            if parts[1].isdigit():
+                                ip_str = parts[0]
+                                port_val = int(parts[1])
+                            else:
+                                ip_str = ip_val_str
+                        else:
+                            ip_str = ip_val_str
 
                 client_str = parse_peer_client(
                     getattr(p, "client", None), getattr(p, "pid", None)
@@ -667,6 +678,7 @@ class DownloadManager:
                 peers.append(
                     PeerInfo(
                         ip=ip_str,
+                        port=port_val,
                         client=client_str,
                         down_speed=down_speed,
                         up_speed=up_speed,

--- a/src/torrra/utils/helpers.py
+++ b/src/torrra/utils/helpers.py
@@ -231,105 +231,12 @@ def get_tomllib():
     return tomllib
 
 
-AZUREUS_CLIENTS: dict[str, str] = {
-    "7T": "aTorrent",
-    "AB": "AnyEvent::BitTorrent",
-    "AG": "Ares",
-    "A~": "Ares",
-    "AR": "Arctic",
-    "AT": "Artemis",
-    "AV": "Avicora",
-    "AZ": "Vuze",
-    "BB": "BitBuddy",
-    "BC": "BitComet",
-    "BE": "Baretorrent",
-    "BF": "BitFlu",
-    "BG": "BTG",
-    "BI": "BiglyBT",
-    "BL": "BitLord",
-    "BP": "BitTorrent Pro",
-    "BR": "BitRocket",
-    "BS": "BTSlave",
-    "BT": "BitTorrent",
-    "BW": "BitWombat",
-    "BX": "BittorrentX",
-    "CD": "Enhanced CTorrent",
-    "CT": "CTorrent",
-    "DE": "Deluge",
-    "DP": "DirectoryPlate",
-    "EB": "EBit",
-    "FC": "FileCroc",
-    "FD": "Free Download Manager",
-    "FG": "FlashGet",
-    "FL": "Folx",
-    "FT": "FoxTorrent",
-    "FW": "FrostWire",
-    "FX": "Freebox BitTorrent",
-    "GR": "GrabBit",
-    "GS": "GSTorrent",
-    "HL": "Halite",
-    "HN": "Hydranode",
-    "KG": "KGet",
-    "KT": "KTorrent",
-    "LH": "LH-ABC",
-    "LK": "Linktorrent",
-    "LP": "Lphant",
-    "LT": "libtorrent",
-    "lt": "libtorrent",
-    "LW": "LimeWire",
-    "MG": "MediaGet",
-    "MK": "Meerkat",
-    "ML": "MLDonkey",
-    "MO": "MonoTorrent",
-    "MP": "MooPolice",
-    "MR": "Miro",
-    "MT": "MoonlightTorrent",
-    "NE": "NetExtensions",
-    "NX": "Net Transport",
-    "OS": "OneSwarm",
-    "OT": "OmegaTorrent",
-    "PD": "Pando",
-    "PI": "PicoTorrent",
-    "QD": "QQDownload",
-    "qB": "qBittorrent",
-    "QT": "QtTorrent",
-    "RT": "Retriever",
-    "SB": "Swiftbit",
-    "SD": "Xunlei",
-    "SN": "Sharenet",
-    "SS": "SwarmScope",
-    "ST": "SymTorrent",
-    "SZ": "Shareaza",
-    "TB": "Torch",
-    "TD": "TidTor",
-    "TL": "Tribler",
-    "TN": "TorrentDotNET",
-    "TO": "Torrra",
-    "TR": "Transmission",
-    "TS": "Tixati",
-    "TT": "TuoTu",
-    "UL": "uLeecher!",
-    "UM": "µTorrent Mac",
-    "UT": "µTorrent",
-    "VG": "Vagaa",
-    "WD": "WebTorrent Desktop",
-    "WT": "BitLet",
-    "WW": "WebTorrent",
-    "WY": "FireTorrent",
-    "XF": "Xfplay",
-    "XL": "Xunlei",
-    "XS": "XSwifter",
-    "XT": "XanTorrent",
-    "XX": "Xtorrent",
-    "ZT": "ZipTorrent",
-}
-
-
 def parse_peer_client(client_raw: object, pid_raw: object) -> str:
-    """Identify a peer's BitTorrent client.
+    """Identify a peer's client or return its peer ID prefix.
 
     Prefers the BEP 10 extended handshake client string if present. Otherwise,
-    parses the 20-byte Peer ID (BEP 20 convention) sent in the initial handshake.
+    returns the client prefix from the 20-byte Peer ID (BEP 20 convention)
+    sent in the initial handshake (e.g. ``-qB4630-``, ``-TR4050-``).
     """
     if client_raw:
         if isinstance(client_raw, bytes):
@@ -352,40 +259,22 @@ def parse_peer_client(client_raw: object, pid_raw: object) -> str:
     elif isinstance(pid_raw, (bytes, bytearray)):
         pid = bytes(pid_raw)
 
-    if not pid or len(pid) < 8 or all(b == 0 for b in pid):
+    if not pid or len(pid) < 4 or all(b == 0 for b in pid):
         return "Unknown"
 
-    # 1. Azureus style: -XX1234-
-    if pid[0:1] == b"-" and pid[7:8] == b"-":
-        code = pid[1:3].decode("ascii", errors="ignore")
-        client_name = AZUREUS_CLIENTS.get(code, code)
-        v_chars: list[str] = []
-        for b in pid[3:7]:
-            if 48 <= b <= 57 or 65 <= b <= 90 or 97 <= b <= 122:
-                v_chars.append(chr(b))
-            else:
-                break
-        if v_chars:
-            res = ".".join(v_chars)
-            while res.endswith(".0") and res.count(".") > 1:
-                res = res[:-2]
-            return f"{client_name} {res}".strip()
-        return client_name
+    # Azureus-style: -XX1234- (8 chars)
+    if pid.startswith(b"-") and len(pid) >= 8 and pid[7:8] == b"-":
+        with suppress(UnicodeDecodeError):
+            return pid[:8].decode("ascii")
 
-    # 2. Mainline style: M3-4-2--...
-    if len(pid) >= 7 and pid[0:1] == b"M" and pid[2:3] == b"-" and pid[4:5] == b"-":
-        try:
-            v = f"{chr(pid[1])}.{chr(pid[3])}.{chr(pid[5])}"
-            return f"BitTorrent {v}"
-        except ValueError:
-            pass
+    # Mainline-style: M3-4-2-- (8 chars)
+    if len(pid) >= 8 and pid[0:1] == b"M" and pid[2:3] == b"-" and pid[4:5] == b"-":
+        with suppress(UnicodeDecodeError):
+            return pid[:8].decode("ascii")
 
-    # 3. BitComet: exbc\x01\x02
-    if len(pid) >= 6 and pid[:4] == b"exbc":
-        return f"BitComet {pid[4]}.{pid[5]:02d}"
-
-    # 4. Free Download Manager: FMD
-    if pid[:3] == b"FMD":
-        return "Free Download Manager"
+    # General printable ASCII prefix (first 8 chars if printable)
+    printable = [chr(b) for b in pid[:8] if 32 <= b <= 126]
+    if len(printable) >= 4:
+        return "".join(printable)
 
     return "Unknown"

--- a/src/torrra/utils/helpers.py
+++ b/src/torrra/utils/helpers.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 from itertools import pairwise
 
 
@@ -228,3 +229,163 @@ def get_tomllib():
         import tomli as tomllib  # type: ignore
 
     return tomllib
+
+
+AZUREUS_CLIENTS: dict[str, str] = {
+    "7T": "aTorrent",
+    "AB": "AnyEvent::BitTorrent",
+    "AG": "Ares",
+    "A~": "Ares",
+    "AR": "Arctic",
+    "AT": "Artemis",
+    "AV": "Avicora",
+    "AZ": "Vuze",
+    "BB": "BitBuddy",
+    "BC": "BitComet",
+    "BE": "Baretorrent",
+    "BF": "BitFlu",
+    "BG": "BTG",
+    "BI": "BiglyBT",
+    "BL": "BitLord",
+    "BP": "BitTorrent Pro",
+    "BR": "BitRocket",
+    "BS": "BTSlave",
+    "BT": "BitTorrent",
+    "BW": "BitWombat",
+    "BX": "BittorrentX",
+    "CD": "Enhanced CTorrent",
+    "CT": "CTorrent",
+    "DE": "Deluge",
+    "DP": "DirectoryPlate",
+    "EB": "EBit",
+    "FC": "FileCroc",
+    "FD": "Free Download Manager",
+    "FG": "FlashGet",
+    "FL": "Folx",
+    "FT": "FoxTorrent",
+    "FW": "FrostWire",
+    "FX": "Freebox BitTorrent",
+    "GR": "GrabBit",
+    "GS": "GSTorrent",
+    "HL": "Halite",
+    "HN": "Hydranode",
+    "KG": "KGet",
+    "KT": "KTorrent",
+    "LH": "LH-ABC",
+    "LK": "Linktorrent",
+    "LP": "Lphant",
+    "LT": "libtorrent",
+    "lt": "libtorrent",
+    "LW": "LimeWire",
+    "MG": "MediaGet",
+    "MK": "Meerkat",
+    "ML": "MLDonkey",
+    "MO": "MonoTorrent",
+    "MP": "MooPolice",
+    "MR": "Miro",
+    "MT": "MoonlightTorrent",
+    "NE": "NetExtensions",
+    "NX": "Net Transport",
+    "OS": "OneSwarm",
+    "OT": "OmegaTorrent",
+    "PD": "Pando",
+    "PI": "PicoTorrent",
+    "QD": "QQDownload",
+    "qB": "qBittorrent",
+    "QT": "QtTorrent",
+    "RT": "Retriever",
+    "SB": "Swiftbit",
+    "SD": "Xunlei",
+    "SN": "Sharenet",
+    "SS": "SwarmScope",
+    "ST": "SymTorrent",
+    "SZ": "Shareaza",
+    "TB": "Torch",
+    "TD": "TidTor",
+    "TL": "Tribler",
+    "TN": "TorrentDotNET",
+    "TO": "Torrra",
+    "TR": "Transmission",
+    "TS": "Tixati",
+    "TT": "TuoTu",
+    "UL": "uLeecher!",
+    "UM": "µTorrent Mac",
+    "UT": "µTorrent",
+    "VG": "Vagaa",
+    "WD": "WebTorrent Desktop",
+    "WT": "BitLet",
+    "WW": "WebTorrent",
+    "WY": "FireTorrent",
+    "XF": "Xfplay",
+    "XL": "Xunlei",
+    "XS": "XSwifter",
+    "XT": "XanTorrent",
+    "XX": "Xtorrent",
+    "ZT": "ZipTorrent",
+}
+
+
+def parse_peer_client(client_raw: object, pid_raw: object) -> str:
+    """Identify a peer's BitTorrent client.
+
+    Prefers the BEP 10 extended handshake client string if present. Otherwise,
+    parses the 20-byte Peer ID (BEP 20 convention) sent in the initial handshake.
+    """
+    if client_raw:
+        if isinstance(client_raw, bytes):
+            decoded = client_raw.decode("utf-8", errors="replace").strip()
+        else:
+            decoded = str(client_raw).strip()
+        if decoded:
+            return decoded
+
+    if not pid_raw:
+        return "Unknown"
+
+    pid = b""
+    to_bytes_fn = getattr(pid_raw, "to_bytes", None)
+    if callable(to_bytes_fn):
+        with suppress(Exception):
+            res = to_bytes_fn()
+            if isinstance(res, (bytes, bytearray)):
+                pid = bytes(res)
+    elif isinstance(pid_raw, (bytes, bytearray)):
+        pid = bytes(pid_raw)
+
+    if not pid or len(pid) < 8 or all(b == 0 for b in pid):
+        return "Unknown"
+
+    # 1. Azureus style: -XX1234-
+    if pid[0:1] == b"-" and pid[7:8] == b"-":
+        code = pid[1:3].decode("ascii", errors="ignore")
+        client_name = AZUREUS_CLIENTS.get(code, code)
+        v_chars: list[str] = []
+        for b in pid[3:7]:
+            if 48 <= b <= 57 or 65 <= b <= 90 or 97 <= b <= 122:
+                v_chars.append(chr(b))
+            else:
+                break
+        if v_chars:
+            res = ".".join(v_chars)
+            while res.endswith(".0") and res.count(".") > 1:
+                res = res[:-2]
+            return f"{client_name} {res}".strip()
+        return client_name
+
+    # 2. Mainline style: M3-4-2--...
+    if len(pid) >= 7 and pid[0:1] == b"M" and pid[2:3] == b"-" and pid[4:5] == b"-":
+        try:
+            v = f"{chr(pid[1])}.{chr(pid[3])}.{chr(pid[5])}"
+            return f"BitTorrent {v}"
+        except ValueError:
+            pass
+
+    # 3. BitComet: exbc\x01\x02
+    if len(pid) >= 6 and pid[:4] == b"exbc":
+        return f"BitComet {pid[4]}.{pid[5]:02d}"
+
+    # 4. Free Download Manager: FMD
+    if pid[:3] == b"FMD":
+        return "Free Download Manager"
+
+    return "Unknown"

--- a/src/torrra/widgets/details_panel.py
+++ b/src/torrra/widgets/details_panel.py
@@ -39,8 +39,9 @@ class DetailsPanel(Vertical):
     ]
 
     PEER_COLS: ClassVar[list[tuple[str, str, int]]] = [
-        ("IP:Port", "ip", 22),
-        ("Client", "client", 20),
+        ("IP", "ip", 18),
+        ("Port", "port", 7),
+        ("Client", "client", 14),
         ("Down", "down_speed", 10),
         ("Up", "up_speed", 10),
         ("Done", "done_percent", 6),
@@ -270,6 +271,7 @@ class DetailsPanel(Vertical):
                 "[dim]-[/dim]",
                 "[dim]-[/dim]",
                 "[dim]-[/dim]",
+                "[dim]-[/dim]",
                 key="__empty__",
             )
             return
@@ -279,7 +281,9 @@ class DetailsPanel(Vertical):
 
         incoming_keys: set[str] = set()
         for idx, p in enumerate(peers):
-            key = p.get("ip") or f"peer_{idx}"
+            ip_raw = p.get("ip", "0.0.0.0")
+            port_raw = p.get("port", 0)
+            key = f"{ip_raw}:{port_raw}" if ip_raw else f"peer_{idx}"
             incoming_keys.add(key)
             down_speed = p.get("down_speed", 0.0)
             up_speed = p.get("up_speed", 0.0)
@@ -290,9 +294,12 @@ class DetailsPanel(Vertical):
             done = f"[b]{int(p.get('progress', 0.0))}%[/b]"
             client = p.get("client", "Unknown")
             flags = f"[dim]{p.get('flags', '-')}[/dim]"
-            ip = f"[dim]{key}[/dim]"
+            ip = f"[dim]{ip_raw}[/dim]"
+            port = f"[dim]{port_raw}[/dim]"
 
             if key in self._peers_table.rows:
+                self._update_cell_if_changed(self._peers_table, key, "ip", ip)
+                self._update_cell_if_changed(self._peers_table, key, "port", port)
                 self._update_cell_if_changed(self._peers_table, key, "client", client)
                 self._update_cell_if_changed(self._peers_table, key, "down_speed", down)
                 self._update_cell_if_changed(self._peers_table, key, "up_speed", up)
@@ -301,7 +308,9 @@ class DetailsPanel(Vertical):
                 )
                 self._update_cell_if_changed(self._peers_table, key, "flags", flags)
             else:
-                self._peers_table.add_row(ip, client, down, up, done, flags, key=key)
+                self._peers_table.add_row(
+                    ip, port, client, down, up, done, flags, key=key
+                )
 
         existing_keys = [str(r.value) for r in self._peers_table.rows]
         for r_key in existing_keys:

--- a/tests/test_core_download.py
+++ b/tests/test_core_download.py
@@ -950,15 +950,17 @@ def test_get_torrent_peers_and_trackers():
     # Test peers
     peers = dm.get_torrent_peers(magnet)
     assert len(peers) == 2
-    assert peers[0]["ip"] == "192.168.1.50:6881"
+    assert peers[0]["ip"] == "192.168.1.50"
+    assert peers[0]["port"] == 6881
     assert peers[0]["client"] == "qBittorrent/4.6.0"
     assert peers[0]["down_speed"] == 500000.0
     assert peers[0]["up_speed"] == 100000.0
     assert peers[0]["progress"] == 75.0
     assert peers[0]["flags"] == "I"
 
-    assert peers[1]["ip"] == "10.0.0.1:51413"
-    assert peers[1]["client"] == "Transmission 4.0.5"
+    assert peers[1]["ip"] == "10.0.0.1"
+    assert peers[1]["port"] == 51413
+    assert peers[1]["client"] == "-TR4050-"
     assert peers[1]["progress"] == 100.0
     assert "s" in peers[1]["flags"]
 

--- a/tests/test_core_download.py
+++ b/tests/test_core_download.py
@@ -898,7 +898,27 @@ def test_get_torrent_peers_and_trackers():
     peer_mock.snubbed = False
     peer_mock.local_connection = False
     peer_mock.seed = False
-    handle_mock.get_peer_info.return_value = [peer_mock]
+
+    # Mock peer 2 (empty client string, identified via peer ID)
+    peer_mock2 = MagicMock()
+    peer_mock2.ip = ("10.0.0.1", 51413)
+    peer_mock2.client = b""
+    pid_mock = MagicMock()
+    pid_mock.to_bytes.return_value = b"-TR4050-123456789012"
+    peer_mock2.pid = pid_mock
+    peer_mock2.down_speed = 0.0
+    peer_mock2.up_speed = 0.0
+    peer_mock2.progress = 1.0
+    peer_mock2.interesting = False
+    peer_mock2.choked = True
+    peer_mock2.remote_interested = False
+    peer_mock2.remote_choked = True
+    peer_mock2.optimistic_unchoke = False
+    peer_mock2.snubbed = False
+    peer_mock2.local_connection = False
+    peer_mock2.seed = True
+
+    handle_mock.get_peer_info.return_value = [peer_mock, peer_mock2]
 
     # Mock tracker
     tracker_mock = MagicMock()
@@ -929,13 +949,18 @@ def test_get_torrent_peers_and_trackers():
 
     # Test peers
     peers = dm.get_torrent_peers(magnet)
-    assert len(peers) == 1
+    assert len(peers) == 2
     assert peers[0]["ip"] == "192.168.1.50:6881"
     assert peers[0]["client"] == "qBittorrent/4.6.0"
     assert peers[0]["down_speed"] == 500000.0
     assert peers[0]["up_speed"] == 100000.0
     assert peers[0]["progress"] == 75.0
     assert peers[0]["flags"] == "I"
+
+    assert peers[1]["ip"] == "10.0.0.1:51413"
+    assert peers[1]["client"] == "Transmission 4.0.5"
+    assert peers[1]["progress"] == 100.0
+    assert "s" in peers[1]["flags"]
 
     # Test trackers
     trackers = dm.get_torrent_trackers(magnet)

--- a/tests/test_utils_helpers.py
+++ b/tests/test_utils_helpers.py
@@ -196,3 +196,37 @@ def test_coerce_seeding_time():
     assert coerce_seeding_time("unlimited") == 0
     assert coerce_seeding_time(False) == 0
     assert coerce_seeding_time("invalid") == 0
+
+
+def test_parse_peer_client():
+    from unittest.mock import MagicMock
+
+    from torrra.utils.helpers import parse_peer_client
+
+    # 1. Extended handshake client string present
+    assert parse_peer_client("Transmission 4.0.5", None) == "Transmission 4.0.5"
+    assert parse_peer_client(b"qBittorrent/4.6.0", None) == "qBittorrent/4.6.0"
+
+    # 2. Azureus-style peer IDs
+    assert parse_peer_client(None, b"-qB4630-123456789012") == "qBittorrent 4.6.3"
+    assert parse_peer_client(b"", b"-TR4050-123456789012") == "Transmission 4.0.5"
+    assert parse_peer_client(None, b"-UT3550-123456789012") == "µTorrent 3.5.5"
+    assert parse_peer_client(None, b"-DE2050-123456789012") == "Deluge 2.0.5"
+    assert parse_peer_client(None, b"-LT2090-123456789012") == "libtorrent 2.0.9"
+    assert parse_peer_client(None, b"-BI2500-123456789012") == "BiglyBT 2.5"
+
+    # 3. Mainline, BitComet, FMD
+    assert parse_peer_client(None, b"M3-4-2--123456789012") == "BitTorrent 3.4.2"
+    assert parse_peer_client(None, b"exbc\x01\x02123456789012") == "BitComet 1.02"
+    assert parse_peer_client(None, b"FMD12345678901234567") == "Free Download Manager"
+
+    # 4. sha1_hash mock with to_bytes
+    hash_mock = MagicMock()
+    hash_mock.to_bytes.return_value = b"-qB4630-123456789012"
+    assert parse_peer_client(None, hash_mock) == "qBittorrent 4.6.3"
+
+    # 5. Unknown fallbacks
+    assert parse_peer_client(None, None) == "Unknown"
+    assert parse_peer_client(b"", b"") == "Unknown"
+    assert parse_peer_client(None, b"\x00" * 20) == "Unknown"
+    assert parse_peer_client(None, b"123") == "Unknown"

--- a/tests/test_utils_helpers.py
+++ b/tests/test_utils_helpers.py
@@ -207,23 +207,22 @@ def test_parse_peer_client():
     assert parse_peer_client("Transmission 4.0.5", None) == "Transmission 4.0.5"
     assert parse_peer_client(b"qBittorrent/4.6.0", None) == "qBittorrent/4.6.0"
 
-    # 2. Azureus-style peer IDs
-    assert parse_peer_client(None, b"-qB4630-123456789012") == "qBittorrent 4.6.3"
-    assert parse_peer_client(b"", b"-TR4050-123456789012") == "Transmission 4.0.5"
-    assert parse_peer_client(None, b"-UT3550-123456789012") == "µTorrent 3.5.5"
-    assert parse_peer_client(None, b"-DE2050-123456789012") == "Deluge 2.0.5"
-    assert parse_peer_client(None, b"-LT2090-123456789012") == "libtorrent 2.0.9"
-    assert parse_peer_client(None, b"-BI2500-123456789012") == "BiglyBT 2.5"
+    # 2. Azureus-style peer ID prefixes
+    assert parse_peer_client(None, b"-qB4630-123456789012") == "-qB4630-"
+    assert parse_peer_client(b"", b"-TR4050-123456789012") == "-TR4050-"
+    assert parse_peer_client(None, b"-UT3550-123456789012") == "-UT3550-"
+    assert parse_peer_client(None, b"-DE2050-123456789012") == "-DE2050-"
+    assert parse_peer_client(None, b"-LT2090-123456789012") == "-LT2090-"
+    assert parse_peer_client(None, b"-BI2500-123456789012") == "-BI2500-"
 
-    # 3. Mainline, BitComet, FMD
-    assert parse_peer_client(None, b"M3-4-2--123456789012") == "BitTorrent 3.4.2"
-    assert parse_peer_client(None, b"exbc\x01\x02123456789012") == "BitComet 1.02"
-    assert parse_peer_client(None, b"FMD12345678901234567") == "Free Download Manager"
+    # 3. Mainline & general ASCII prefixes
+    assert parse_peer_client(None, b"M3-4-2--123456789012") == "M3-4-2--"
+    assert parse_peer_client(None, b"FMD12345678901234567") == "FMD12345"
 
     # 4. sha1_hash mock with to_bytes
     hash_mock = MagicMock()
     hash_mock.to_bytes.return_value = b"-qB4630-123456789012"
-    assert parse_peer_client(None, hash_mock) == "qBittorrent 4.6.3"
+    assert parse_peer_client(None, hash_mock) == "-qB4630-"
 
     # 5. Unknown fallbacks
     assert parse_peer_client(None, None) == "Unknown"

--- a/tests/test_widgets_details_panel.py
+++ b/tests/test_widgets_details_panel.py
@@ -94,7 +94,8 @@ async def test_details_panel_tabs_and_data_tables():
         panel.update_peers(
             [
                 PeerInfo(
-                    ip="1.2.3.4:5678",
+                    ip="1.2.3.4",
+                    port=5678,
                     client="Transmission/4.0",
                     down_speed=1024.0 * 1024.0,
                     up_speed=512.0 * 1024.0,
@@ -175,7 +176,8 @@ async def test_details_panel_in_place_updates_and_scroll_retention():
         # Generate 20 peers
         initial_peers = [
             PeerInfo(
-                ip=f"10.0.0.{i}:6881",
+                ip=f"10.0.0.{i}",
+                port=6881,
                 client=f"Client/{i}",
                 down_speed=1000.0 * i,
                 up_speed=500.0 * i,
@@ -196,7 +198,8 @@ async def test_details_panel_in_place_updates_and_scroll_retention():
         # Update peers in-place (same peer list, updated speeds/progress)
         updated_peers = [
             PeerInfo(
-                ip=f"10.0.0.{i}:6881",
+                ip=f"10.0.0.{i}",
+                port=6881,
                 client=f"Client/{i}",
                 down_speed=2000.0 * i,
                 up_speed=1000.0 * i,
@@ -215,7 +218,8 @@ async def test_details_panel_in_place_updates_and_scroll_retention():
         # Remove peer 0, add new peer 99
         updated_peers = updated_peers[1:] + [
             PeerInfo(
-                ip="10.0.0.99:6881",
+                ip="10.0.0.99",
+                port=6881,
                 client="Client/99",
                 down_speed=5000.0,
                 up_speed=1000.0,


### PR DESCRIPTION
### Summary
Displays peer software prefixes and splits IP and Port into distinct columns in the Peers details table.

### Changes
- **Client Prefix Resolution**:
  - Removed full-name client lookup dictionary.
  - Prefers extended handshake client string (BEP 10) if present.
  - Otherwise, directly displays the 8-character client identifier prefix encoded in the 20-byte Peer ID (BEP 20 convention, e.g. `-qB4630-`, `-TR4050-`, `-UT3550-`, `M3-4-2--`).
- **Separate IP & Port Columns**:
  - Added dedicated `Port` column next to `IP` in the Peers table.
  - Updated `PeerInfo` TypedDict with `port: int`.
  - Updated `DownloadManager.get_torrent_peers()` to parse IP address and port number separately.
- **Tests**:
  - Updated unit tests in `test_utils_helpers.py`, `test_core_download.py`, and `test_widgets_details_panel.py`.
